### PR TITLE
[doc] pin version to plone.restapi grater then 7.0.0a1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "setuptools",
         "z3c.jbot",
         "plone.api>=1.8.4",
-        # "plone.restapi>=7.0.0",
+        "plone.restapi>=7.0.0a1",
         "plone.restapi",
         "plone.app.dexterity",
         "collective.folderishtypes[dexterity]>=3.0.0",


### PR DESCRIPTION
Because of [this](https://github.com/RedTurtle/redturtle.volto/blob/3675dce24d7adad426605ec81a743406068cd387/src/redturtle/volto/restapi/deserializer/blocks.py#L4)