### PR TITLE
Remove default cache proxy address on install

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove default cache proxy address on install.
+  [cekk]
 
 
 3.1.3 (2021-06-30)

--- a/src/redturtle/volto/profiles/default/registry/caching.xml
+++ b/src/redturtle/volto/profiles/default/registry/caching.xml
@@ -23,11 +23,6 @@
   <record name="plone.app.caching.strongCaching.plone.stableResource.maxage">
     <value>86400</value>
   </record>
-  <record name="plone.cachepurging.interfaces.ICachePurgingSettings.cachingProxies" interface="plone.cachepurging.interfaces.ICachePurgingSettings" field="cachingProxies">
-    <value>
-      <element>http://localhost:9068</element>
-    </value>
-  </record>
   <record name="plone.cachepurging.interfaces.ICachePurgingSettings.enabled" interface="plone.cachepurging.interfaces.ICachePurgingSettings" field="enabled">
     <value>True</value>
   </record>


### PR DESCRIPTION
This avoid a lot of errors/warnings on development sites.
We need to set it manually anyway in production.