### PR TITLE
Fix blocks serialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 - Allow to select custom miniature for RSS template
   [lucabel]
-
+- Better serialize refs in blocks: now we don't serialize the full object, but only the summary (with all metadata) to decrease (A LOT) the size of the response.
+  [cekk]
 
 3.8.3 (2022-03-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,8 @@ Custom blocks transformers
 
 There are custom transformers for serializer and deserializer to better manage resolveuids.
 
-There is an edge-case when a block refers its context: in this case, to avoid maximum recursion depth
-in uids resolving, that uid will be expanded with the Summary json version and not the full object.
-
+If a block refers to some internal content, on deserialization we only store its UID, and in serialization
+we "expand" informations with the summary-serialized content.
 
 @context-navigation endpoint
 ----------------------------

--- a/src/redturtle/volto/restapi/serializer/blocks.py
+++ b/src/redturtle/volto/restapi/serializer/blocks.py
@@ -5,7 +5,6 @@ from plone import api
 from plone.indexer.interfaces import IIndexableObject
 from plone.restapi.behaviors import IBlocks
 from plone.restapi.interfaces import IBlockFieldSerializationTransformer
-from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.blocks import uid_to_url
 from Products.CMFPlone.interfaces import IPloneSiteRoot

--- a/src/redturtle/volto/restapi/serializer/summary.py
+++ b/src/redturtle/volto/restapi/serializer/summary.py
@@ -117,13 +117,12 @@ class DefaultJSONSummarySerializer(BaseSerializer):
         if scales:
             data["image"] = {"scales": scales}
         if self.context.portal_type == "Link":
-            if "remoteUrl" in metadata_fields or self.show_all_metadata_fields:
-                remote_url = self.get_remote_url()
-                # set twice because old templates can use both
-                if not remote_url:
-                    data["getRemoteUrl"] = ""
-                    data["remoteUrl"] = ""
-                else:
-                    data["remoteUrl"] = remote_url
-                    data["getRemoteUrl"] = remote_url
+            remote_url = self.get_remote_url()
+            # set twice because old templates can use both
+            if not remote_url:
+                data["getRemoteUrl"] = ""
+                data["remoteUrl"] = ""
+            else:
+                data["remoteUrl"] = remote_url
+                data["getRemoteUrl"] = remote_url
         return data

--- a/src/redturtle/volto/restapi/serializer/summary.py
+++ b/src/redturtle/volto/restapi/serializer/summary.py
@@ -103,7 +103,6 @@ class DefaultJSONSummarySerializer(BaseSerializer):
         if force_all_metadata:
             self.force_all_metadata = True
         data = super().__call__()
-        metadata_fields = self.metadata_fields()
         # return empty values if dates are not set:
         for k, v in data.items():
             if isinstance(v, str):

--- a/src/redturtle/volto/restapi/serializer/summary.py
+++ b/src/redturtle/volto/restapi/serializer/summary.py
@@ -24,21 +24,38 @@ EMPTY_STRINGS = ["None"]
 @implementer(ISerializeToJsonSummary)
 @adapter(Interface, IRedturtleVoltoLayer)
 class DefaultJSONSummarySerializer(BaseSerializer):
-    def get_metadata_fields(self):
+    def __init__(self, context, request):
+        super().__init__(context, request)
+        self.force_all_metadata = False
+
+    def metadata_fields(self):
+        metadata_fields = super().metadata_fields()
+        if not self.force_all_metadata:
+            return metadata_fields
+        fields_cache = self.request.get("_summary_fields_cache", None)
+        if fields_cache is None:
+            catalog = api.portal.get_tool(name="portal_catalog")
+            fields_cache = set(catalog.schema()) | self.non_metadata_attributes
+            self.request.set("_summary_fields_cache", fields_cache)
+        return metadata_fields | fields_cache
+
+    @property
+    def show_all_metadata_fields(self):
         query = self.request.form
         if not query:
             # maybe its a POST request
             query = json_body(self.request)
-        return query.get("metadata_fields", []) or []
+        metadata_fields = query.get("metadata_fields", [])
+        return "_all" in metadata_fields or self.force_all_metadata
 
     def get_image_scales(self, data):
         """
         this is a backward compatibility for old volto templates that need
         a full image scales object
         """
-        metadata_fields = self.get_metadata_fields()
+        metadata_fields = self.metadata_fields()
 
-        if "_all" not in metadata_fields:
+        if "image" not in metadata_fields and not self.show_all_metadata_fields:
             return {}
         if data.get("image", None):
             # it's a fullobjects data, so we already have the infos
@@ -46,6 +63,7 @@ class DefaultJSONSummarySerializer(BaseSerializer):
         if not data.get("image_field", ""):
             return None
         scales = {}
+
         for name, actual_width, actual_height in get_scale_infos():
             scales[name] = {
                 "width": actual_width,
@@ -81,9 +99,11 @@ class DefaultJSONSummarySerializer(BaseSerializer):
                 return ""
         return ""
 
-    def __call__(self):
+    def __call__(self, force_all_metadata=False):
+        if force_all_metadata:
+            self.force_all_metadata = True
         data = super().__call__()
-        metadata_fields = self.get_metadata_fields()
+        metadata_fields = self.metadata_fields()
         # return empty values if dates are not set:
         for k, v in data.items():
             if isinstance(v, str):
@@ -93,10 +113,11 @@ class DefaultJSONSummarySerializer(BaseSerializer):
                 # this is a Volto compatibility
                 data[k] = None
         scales = self.get_image_scales(data)
+
         if scales:
             data["image"] = {"scales": scales}
         if self.context.portal_type == "Link":
-            if "_all" in metadata_fields or "remoteUrl" in metadata_fields:
+            if "remoteUrl" in metadata_fields or self.show_all_metadata_fields:
                 remote_url = self.get_remote_url()
                 # set twice because old templates can use both
                 if not remote_url:

--- a/src/redturtle/volto/tests/test_blocks_serializer.py
+++ b/src/redturtle/volto/tests/test_blocks_serializer.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from multiprocessing.context import _force_start_method
 from plone import api
 from plone.app.testing import (
     SITE_OWNER_NAME,
@@ -11,7 +10,6 @@ from plone.restapi.testing import RelativeSession
 from redturtle.volto.testing import REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
 from transaction import commit
 from plone.restapi.interfaces import ISerializeToJsonSummary
-from plone.restapi.interfaces import ISerializeToJson
 from zope.component import getMultiAdapter
 
 import unittest

--- a/src/redturtle/volto/tests/test_blocks_serializer.py
+++ b/src/redturtle/volto/tests/test_blocks_serializer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from multiprocessing.context import _force_start_method
 from plone import api
 from plone.app.testing import (
     SITE_OWNER_NAME,
@@ -48,7 +49,7 @@ class TestBlocksSerializer(unittest.TestCase):
     def tearDown(self):
         self.api_session.close()
 
-    def test_blocks_internal_refs_with_uid_get_serialized(self):
+    def test_blocks_internal_refs_with_uid_get_serialized_as_summary(self):
 
         self.page_a.blocks = {
             "foo": {
@@ -58,11 +59,13 @@ class TestBlocksSerializer(unittest.TestCase):
         }
         commit()
         response = self.api_session.get(self.page_a.absolute_url())
-
+        brain = api.content.find(UID=self.page_b.UID())[0]
         res = response.json()
         self.assertEqual(
             res["blocks"]["foo"]["field"][0],
-            getMultiAdapter((self.page_b, self.request), ISerializeToJson)(),
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)(
+                force_all_metadata=True
+            ),
         )
 
     def test_blocks_internal_refs_dont_generate_recursion_depth(self):
@@ -75,9 +78,11 @@ class TestBlocksSerializer(unittest.TestCase):
         }
         commit()
         response = self.api_session.get(self.page_a.absolute_url())
-
+        brain = api.content.find(UID=self.page_a.UID())[0]
         res = response.json()
         self.assertEqual(
             res["blocks"]["foo"]["field"][0],
-            getMultiAdapter((self.page_a, self.request), ISerializeToJsonSummary)(),
+            getMultiAdapter((brain, self.request), ISerializeToJsonSummary)(
+                force_all_metadata=True
+            ),
         )


### PR DESCRIPTION
Now serialize references in blocks with the summary (with all metadata) and not the full object.
For example, this decrease the response size of an homepage from 10mb to 84k