### PR TITLE
set authorization bearer header from auth_token cookie

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,10 @@ jobs:
           bin/code-analysis
       - name: Run tests
         run: |
-          TZ=${{ matrix.tz }} bin/test-coverage
+          bin/test-coverage
+          env:
+            PROXY_BEARER_AUTH: on
+            TZ: ${{ matrix.tz }}
       - name: Upload coverage data to coveralls.io
         run: |
           pip install coveralls

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Run tests
         run: |
           bin/test-coverage
-          env:
-            PROXY_BEARER_AUTH: on
-            TZ: ${{ matrix.tz }}
+        env:
+          PROXY_BEARER_AUTH: on
+          TZ: ${{ matrix.tz }}
       - name: Upload coverage data to coveralls.io
         run: |
           pip install coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- set authorization bearer header from auth_token cookie
+  [mamico]
 
 
 5.0.1 (2023-07-04)

--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,13 @@ Default ISerializeToJsonSummary adapter
 
 This is a patch for backward compatibility for old volto templates that need a full image scales object.
 
+Authentication Header
+---------------------
+
+There is a custom event handler for IPubStart that set authorization bearer header from auth_token cookie.
+For details see the `pull-request <https://github.com/RedTurtle/redturtle.volto/pull/69>`_.
+
+This patch is not enabled by default. You need to set an environment variable to `true`: *PROXY_BEARER_AUTH*.
 
 New Criteria
 ============

--- a/base.cfg
+++ b/base.cfg
@@ -116,3 +116,4 @@ scripts =
 [versions]
 # Don't use a released version of redturtle.volto
 redturtle.volto =
+setuptools = 

--- a/src/redturtle/volto/configure.zcml
+++ b/src/redturtle/volto/configure.zcml
@@ -42,4 +42,9 @@
       name="redturtle.volto-hiddenprofiles"
       />
 
+  <subscriber
+    for="ZPublisher.interfaces.IPubStart"
+    handler=".events.manage_auth_token"
+    />
+
 </configure>

--- a/src/redturtle/volto/configure.zcml
+++ b/src/redturtle/volto/configure.zcml
@@ -43,8 +43,8 @@
       />
 
   <subscriber
-    for="ZPublisher.interfaces.IPubStart"
-    handler=".events.manage_auth_token"
-    />
+      for="ZPublisher.interfaces.IPubStart"
+      handler=".events.manage_auth_token"
+      />
 
 </configure>

--- a/src/redturtle/volto/events.py
+++ b/src/redturtle/volto/events.py
@@ -1,3 +1,6 @@
+import os
+
+
 def manage_auth_token(event):
     """
     set authorization header from cookie
@@ -6,9 +9,10 @@ def manage_auth_token(event):
         https://github.com/plone/plone.restapi/issues/148
         https://github.com/plone/plone.restapi/pull/1303
     """
-    request = event.request
-    if getattr(request, "_auth", None):
-        return
-    auth_token = request.cookies.get("auth_token")
-    if auth_token:
-        request._auth = "Bearer " + auth_token
+    if os.environ.get("PROXY_BEARER_AUTH"):
+        request = event.request
+        if getattr(request, "_auth", None):
+            return
+        auth_token = request.cookies.get("auth_token")
+        if auth_token:
+            request._auth = "Bearer " + auth_token

--- a/src/redturtle/volto/events.py
+++ b/src/redturtle/volto/events.py
@@ -1,9 +1,8 @@
-
 def manage_auth_token(event):
     """
     set authorization header from cookie
-    
-    see: 
+
+    see:
         https://github.com/plone/plone.restapi/issues/148
         https://github.com/plone/plone.restapi/pull/1303
     """

--- a/src/redturtle/volto/events.py
+++ b/src/redturtle/volto/events.py
@@ -1,0 +1,15 @@
+
+def manage_auth_token(event):
+    """
+    set authorization header from cookie
+    
+    see: 
+        https://github.com/plone/plone.restapi/issues/148
+        https://github.com/plone/plone.restapi/pull/1303
+    """
+    request = event.request
+    if getattr(request, "_auth", None):
+        return
+    auth_token = request.cookies.get("auth_token")
+    if auth_token:
+        request._auth = "Bearer " + auth_token


### PR DESCRIPTION
the problem has been discussed https://github.com/plone/plone.restapi/issues/148 andhttps://github.com/plone/plone.restapi/pull/1303

To summarize, the main problem is that if in the proxy rules, requests for files and images are forwarded directly to `plone`, the `auth_token` cookie is not considered and the user is anonymous. 

The solution proposed here only works in cases where the backend domain (`plone`) and the  frontend domain (`volto`) match.