### PR TITLE
fix: fix-links behavior due to a problem with external links substitution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 5.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix: the 'fix-link' view has a bug that corrupts links by replacing
+  the current external URL with a URL that is always relative to the
+  site, even when requesting replacement with a link from a different
+  website.
+  [lucabel].
 
 
 5.2.4 (2023-09-26)

--- a/src/redturtle/volto/browser/fix_links.py
+++ b/src/redturtle/volto/browser/fix_links.py
@@ -6,6 +6,7 @@ from plone.restapi.interfaces import IFieldDeserializer
 from Products.Five import BrowserView
 from zope.component import queryMultiAdapter
 from zope.schema import getFieldsInOrder
+from urllib.parse import urlparse, urlunparse
 
 import json
 import logging
@@ -68,6 +69,7 @@ class View(BrowserView):
                         # set the new value anyway because some values could not be transformed,
                         # but they now have the right url anyway.
                         setattr(item, name, res["new_value"])
+                        item.reindexObject()
             i += 1
         logger.info("### END ###")
         logger.info("### {} items fixed ###".format(len(fixed_objects)))
@@ -94,6 +96,10 @@ class View(BrowserView):
                 return True
 
     def replace_pattern(self, value, is_link=False):
+        # obtain data to make link sub evaluation
+        current_host = urlparse(self.request.URL).netloc
+        destination_host = urlparse(self.portal_url).netloc
+
         for url in self.request.form.get("to_replace", "").split():
             match = re.search(r"(?<={}).*".format(url), value)
             if match:
@@ -106,7 +112,11 @@ class View(BrowserView):
                     return value
                 if obj:
                     if is_link:
-                        return "${portal_url}/resolveuid/" + obj.UID()
+                        if current_host != destination_host:
+                            new_url = urlparse(value)._replace(netloc=destination_host)
+                            return urlunparse(new_url)
+                        else:
+                            return "${portal_url}/resolveuid/" + obj.UID()
                     else:
                         return obj.UID()
         return value


### PR DESCRIPTION
Problem is that if we change testurl.it with correcturl.it on a link ct
the subs it's always changing with a site relative domain.

eg.
testurl.it/testA will be always changed with /${portal_url}/resolveuid/1234567890
with 1234567890 the UID of testA.

if correcturl.it it's a different site this behavior will brake the link
