### PR TITLE
Set search/querystring-search limit patch only for anonymous users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,14 @@ Changelog
   site, even when requesting replacement with a link from a different
   website.
   [lucabel].
+
 - plone.app.redirector.FourOhFourView.search_for_similar patch to enable conditionally
   the search for similar
   [folix-01]
 
+- Set search/querystring-search limit patch only for anonymous users.
+  Auth users can need to perform an higher query (in contents view for example).
+  [cekk]
 
 5.2.4 (2023-09-26)
 ------------------

--- a/src/redturtle/volto/restapi/services/search/get.py
+++ b/src/redturtle/volto/restapi/services/search/get.py
@@ -124,26 +124,30 @@ class SearchHandler(OriginalHandler):
         return super(SearchHandler, self).search(query)
 
     def _parse_query(self, query):
+        """
+        set a max limit for anonymous calls
+        """
         query = super()._parse_query(query)
-        for idx in ["sort_limit", "b_size"]:
-            if idx not in query:
-                continue
-            value = query.get(idx, MAX_LIMIT)
-            if value <= 0:
-                logger.warning(
-                    '[wrong query] {} is wrong: "{}". Set to default ({}).'.format(
-                        idx, query, MAX_LIMIT
+        if api.user.is_anonymous():
+            for idx in ["sort_limit", "b_size"]:
+                if idx not in query:
+                    continue
+                value = query.get(idx, MAX_LIMIT)
+                if value <= 0:
+                    logger.warning(
+                        '[wrong query] {} is wrong: "{}". Set to default ({}).'.format(
+                            idx, query, MAX_LIMIT
+                        )
                     )
-                )
-                query[idx] = MAX_LIMIT
+                    query[idx] = MAX_LIMIT
 
-            if value > MAX_LIMIT:
-                logger.warning(
-                    '[wrong query] {} is too high: "{}". Set to default ({}).'.format(
-                        idx, query, MAX_LIMIT
+                if value > MAX_LIMIT:
+                    logger.warning(
+                        '[wrong query] {} is too high: "{}". Set to default ({}).'.format(
+                            idx, query, MAX_LIMIT
+                        )
                     )
-                )
-                query[idx] = MAX_LIMIT
+                    query[idx] = MAX_LIMIT
         return query
 
 

--- a/src/redturtle/volto/tests/test_catalog_limit_patches.py
+++ b/src/redturtle/volto/tests/test_catalog_limit_patches.py
@@ -25,29 +25,80 @@ class CatalogLimitPatches(unittest.TestCase):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
         for i in range(self.MAX_LIMIT + 1):
-            api.content.create(
+            doc = api.content.create(
                 container=self.portal,
                 type="Document",
                 title=f"Document {i}",
             )
+            api.content.transition(obj=doc, transition="publish")
         commit()
 
         self.api_session = RelativeSession(self.portal_url)
         self.api_session.headers.update({"Accept": "application/json"})
         self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
+        self.api_session_anon = RelativeSession(self.portal_url)
+        self.api_session_anon.headers.update({"Accept": "application/json"})
+
     def tearDown(self):
         self.api_session.close()
+        self.api_session_anon.close()
 
-    def test_search_b_size_default_to_500(self):
+    def test_search_b_size_not_limited_for_auth(self):
         response = self.api_session.get(
+            "/@search", params={"portal_type": "Document", "b_size": 1000}
+        )
+        result = response.json()
+        self.assertEqual(len(result["items"]), self.MAX_LIMIT + 1)
+
+    def test_querystringsearch_post_not_limited_for_auth(self):
+        response = self.api_session.post(
+            "/@querystring-search",
+            json={
+                "query": [
+                    {
+                        "i": "portal_type",
+                        "o": "plone.app.querystring.operation.selection.is",
+                        "v": ["Document"],
+                    }
+                ],
+                "limit": 2000,
+                "b_size": 2000,
+            },
+        )
+        result = response.json()
+        self.assertEqual(len(result["items"]), self.MAX_LIMIT + 1)
+        self.assertEqual(result["items_total"], self.MAX_LIMIT + 1)
+
+    def test_querystringsearch_get_not_limited_for_auth(self):
+        query = {
+            "query": [
+                {
+                    "i": "portal_type",
+                    "o": "plone.app.querystring.operation.selection.any",
+                    "v": ["Document"],
+                }
+            ],
+            "b_size": 2000,
+            "limit": 2000,
+        }
+        response = self.api_session.get(
+            f"/@querystring-search?query={quote(json.dumps(query))}",
+        )
+
+        result = response.json()
+        self.assertEqual(len(result["items"]), self.MAX_LIMIT + 1)
+        self.assertEqual(result["items_total"], self.MAX_LIMIT + 1)
+
+    def test_search_b_size_default_to_500_for_anon(self):
+        response = self.api_session_anon.get(
             "/@search", params={"portal_type": "Document", "b_size": 1000}
         )
         result = response.json()
         self.assertEqual(len(result["items"]), self.MAX_LIMIT)
 
-    def test_querystringsearch_post_default_limit_500(self):
-        response = self.api_session.post(
+    def test_querystringsearch_post_default_limit_500_for_anon(self):
+        response = self.api_session_anon.post(
             "/@querystring-search",
             json={
                 "query": [
@@ -65,7 +116,7 @@ class CatalogLimitPatches(unittest.TestCase):
         self.assertEqual(len(result["items"]), self.MAX_LIMIT)
         self.assertEqual(result["items_total"], self.MAX_LIMIT)
 
-    def test_querystringsearch_get_default_limit_500(self):
+    def test_querystringsearch_get_default_limit_500_for_anon(self):
         query = {
             "query": [
                 {
@@ -77,7 +128,7 @@ class CatalogLimitPatches(unittest.TestCase):
             "b_size": 2000,
             "limit": 2000,
         }
-        response = self.api_session.get(
+        response = self.api_session_anon.get(
             f"/@querystring-search?query={quote(json.dumps(query))}",
         )
 


### PR DESCRIPTION
Auth users can need to set an higher limit in query (in contents view for example)