### PR TITLE
add patch to modidify indexing of start index

### DIFF
--- a/src/redturtle/volto/monkey.py
+++ b/src/redturtle/volto/monkey.py
@@ -8,7 +8,8 @@ from plone.app.event.base import dt_start_of_day
 from plone.app.event.dx.behaviors import IEventBasic
 from plone.app.event.recurrence import Occurrence
 from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
-from plone.event.interfaces import IEventAccessor, IRecurrenceSupport
+from plone.event.interfaces import IEventAccessor
+from plone.event.interfaces import IRecurrenceSupport
 from plone.event.recurrence import recurrence_sequence_ical
 from plone.event.utils import pydt
 from Products.CMFPlone.interfaces import IConstrainTypes

--- a/src/redturtle/volto/monkey.py
+++ b/src/redturtle/volto/monkey.py
@@ -5,9 +5,10 @@ import os
 from Acquisition import aq_base
 from plone.app.caching import purge
 from plone.app.event.base import dt_start_of_day
+from plone.app.event.dx.behaviors import IEventBasic
 from plone.app.event.recurrence import Occurrence
 from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
-from plone.event.interfaces import IEventAccessor
+from plone.event.interfaces import IEventAccessor, IRecurrenceSupport
 from plone.event.recurrence import recurrence_sequence_ical
 from plone.event.utils import pydt
 from Products.CMFPlone.interfaces import IConstrainTypes
@@ -60,6 +61,7 @@ def occurrences(self, range_start=None, range_end=None):
         else:
             duration = event_end - event_start
         # END OF PATCH
+
     starts = recurrence_sequence_ical(
         event_start,
         recrule=event.recurrence,
@@ -85,6 +87,17 @@ def occurrences(self, range_start=None, range_end=None):
 
     for start in starts:
         yield get_obj(start)
+
+
+def _recurrence_upcoming_event(self):
+    """Return the next upcoming event"""
+    adapter = IRecurrenceSupport(self.context)
+    occs = adapter.occurrences()
+    try:
+        return next(occs)
+    except StopIteration:
+        # No more future occurrences: passed event
+        return IEventBasic(self.context)
 
 
 def _verifyObjectPaste(self, obj, validate_src=True):

--- a/src/redturtle/volto/monkey.zcml
+++ b/src/redturtle/volto/monkey.zcml
@@ -13,7 +13,7 @@
       description="This fix the problem with Events recurrences"
       />
 
-    <monkey:patch
+  <monkey:patch
       original="_recurrence_upcoming_event"
       replacement=".monkey._recurrence_upcoming_event"
       class="plone.app.event.dx.behaviors.EventAccessor"

--- a/src/redturtle/volto/monkey.zcml
+++ b/src/redturtle/volto/monkey.zcml
@@ -13,6 +13,13 @@
       description="This fix the problem with Events recurrences"
       />
 
+    <monkey:patch
+      original="_recurrence_upcoming_event"
+      replacement=".monkey._recurrence_upcoming_event"
+      class="plone.app.event.dx.behaviors.EventAccessor"
+      description="This fix the problem with Events recurrences"
+      />
+
   <monkey:patch
       original="_verifyObjectPaste"
       replacement=".monkey._verifyObjectPaste"

--- a/src/redturtle/volto/profiles/default/metadata.xml
+++ b/src/redturtle/volto/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>4300</version>
+  <version>4301</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-plone.app.caching:with-caching-proxy</dependency>

--- a/src/redturtle/volto/upgrades.py
+++ b/src/redturtle/volto/upgrades.py
@@ -463,3 +463,12 @@ def to_4200(context):
     logger.info("Add redturtle.volto controlpanel")
     update_registry(context)
     update_controlpanel(context)
+
+
+def to_4301(context):
+    brains = api.content.find(portal_type="Event")
+    logger.info("Reindexing {} Events".format(len(brains)))
+
+    for brain in brains:
+        event = brain.getObject()
+        event.reindexObject(idxs=["start"])

--- a/src/redturtle/volto/upgrades.zcml
+++ b/src/redturtle/volto/upgrades.zcml
@@ -189,4 +189,13 @@
       handler=".setuphandlers.upgrade_robots_txt"
       />
 
+  <genericsetup:upgradeStep
+      title="Rendex start index"
+      description=""
+      profile="redturtle.volto:default"
+      source="4300"
+      destination="4301"
+      handler=".upgrades.to_4301"
+      />
+
 </configure>


### PR DESCRIPTION
Modificato il comportamento per l'indicizzazione della start date degli eventi, perché altrimenti la vista dello scadenziario non funziona bene.