### PR TITLE
Do not try to convert strings in internal paths for *form* blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.4.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not try to convert strings in internal paths for *form* blocks.
+  [cekk]
 
 
 5.4.7 (2024-03-11)

--- a/src/redturtle/volto/restapi/deserializer/blocks.py
+++ b/src/redturtle/volto/restapi/deserializer/blocks.py
@@ -10,7 +10,7 @@ from zope.interface import implementer
 
 
 EXCLUDE_KEYS = ["@type", "token", "value", "@id", "query"]
-EXCLUDE_TYPES = ["title", "listing", "calendar", "searchEvents"]
+EXCLUDE_TYPES = ["title", "listing", "calendar", "searchEvents", "form"]
 
 
 class GenericResolveUIDDeserializer(object):

--- a/src/redturtle/volto/restapi/serializer/blocks.py
+++ b/src/redturtle/volto/restapi/serializer/blocks.py
@@ -14,7 +14,7 @@ from zope.interface import implementer
 
 
 EXCLUDE_KEYS = ["@type"]
-EXCLUDE_TYPES = ["title", "listing"]
+EXCLUDE_TYPES = ["title", "listing", "form"]
 
 
 class GenericResolveUIDSerializer(object):


### PR DESCRIPTION
This could generate some problems for example when adding a field with options, and one option have the same name as a content id..we don't want to convert it into an internal path.