### PR TITLE
Querystringsearch patch for missing absolutePath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Patch in @querystring-search that avoid to search through all the site if there is an absolutePath criteria with non existing UID and b_size==1.
+  See #99 for more details.
   [cekk]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.4.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Patch in @querystring-search that avoid to search through all the site if there is an absolutePath criteria with non existing UID and b_size==1.
+  [cekk]
 
 
 5.4.7 (2024-03-11)

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -34,6 +34,7 @@ class QuerystringSearch(BaseQuerystringSearch):
             raise BadRequest(str(err))
 
         query = data.get("query", None)
+
         if self.is_event_search(query=query):
             return self.reply_events()
 
@@ -49,6 +50,8 @@ class QuerystringSearch(BaseQuerystringSearch):
             return dict(error=dict(type="BadRequest", message="Invalid b_size"))
         sort_on = data.get("sort_on", None)
         sort_order = data.get("sort_order", None)
+
+        query = self.cleanup_query(query=query, b_size=b_size)
 
         # LIMIT PATCH
         if not query:
@@ -96,6 +99,40 @@ class QuerystringSearch(BaseQuerystringSearch):
             fullobjects=fullobjects
         )
         return results
+
+    def cleanup_query(self, query, b_size):
+        """
+        If b_size == 1 and there is an absolutePath in query that points to a non
+        existing content, reeturn empty query.
+        This is the case where absolutePath points to an UID that is not present on the site.
+        A call with b_size == 1 usually is made in objectbrowser to draw the reference, but with a
+        wrong UID, Plone by default return all site contents and the first one will be returned.
+        If you then save the blocks, you'll have that random content as new absolutePath value.
+        """
+        if b_size != 1:
+            return query
+        fixed_query = []
+        for criteria in query:
+            index = criteria.get("i", "")
+            operation = criteria.get("o", "")
+            if (
+                index == "path"
+                and operation == "plone.app.querystring.operation.string.absolutePath"
+            ):
+                criteria_value = criteria.get("v", "").split("::")
+                value = criteria_value[0]
+
+                if "/" not in value:
+                    # It must be a UID
+                    item = api.content.get(UID=value)
+                    if not item:
+                        continue
+                else:
+                    item = api.content.get(value)
+                    if not item:
+                        continue
+            fixed_query.append(query)
+        return fixed_query
 
     def get_limit(self, data):
         """

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -118,7 +118,7 @@ class QuerystringSearch(BaseQuerystringSearch):
             if (
                 index == "path"
                 and operation  # noqa
-                == "plone.app.querystring.operation.string.absolutePath"
+                == "plone.app.querystring.operation.string.absolutePath"  # noqa
             ):
                 criteria_value = criteria.get("v", "").split("::")
                 value = criteria_value[0]

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -117,7 +117,8 @@ class QuerystringSearch(BaseQuerystringSearch):
             operation = criteria.get("o", "")
             if (
                 index == "path"
-                and operation == "plone.app.querystring.operation.string.absolutePath"
+                and operation  # noqa
+                == "plone.app.querystring.operation.string.absolutePath"
             ):
                 criteria_value = criteria.get("v", "").split("::")
                 value = criteria_value[0]

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -132,7 +132,7 @@ class QuerystringSearch(BaseQuerystringSearch):
                     item = api.content.get(value)
                     if not item:
                         continue
-            fixed_query.append(query)
+            fixed_query.append(criteria)
         return fixed_query
 
     def get_limit(self, data):

--- a/src/redturtle/volto/tests/test_querystringsearch.py
+++ b/src/redturtle/volto/tests/test_querystringsearch.py
@@ -7,9 +7,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.restapi.testing import RelativeSession
 from redturtle.volto.testing import REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
 from transaction import commit
-from urllib.parse import quote
 
-import json
 import unittest
 
 

--- a/src/redturtle/volto/tests/test_querystringsearch.py
+++ b/src/redturtle/volto/tests/test_querystringsearch.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.restapi.testing import RelativeSession
+from redturtle.volto.testing import REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
+from transaction import commit
+from urllib.parse import quote
+
+import json
+import unittest
+
+
+class TestQuerystringSearch(unittest.TestCase):
+    layer = REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        api.content.create(container=self.portal, type="Document", title="First")
+        api.content.create(container=self.portal, type="Document", title="Second")
+        commit()
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+    def tearDown(self):
+        self.api_session.close()
+
+    def test_do_not_return_random_item_in_objectbrowser_call_if_absolutePath_is_invalid(
+        self,
+    ):
+        """
+        objectbrowser calls always ask for an absolutePath adn b_size == 1.
+        absolutePath is the uid of the referenced object
+        """
+        response = self.api_session.post(
+            "/@querystring-search",
+            json={
+                "query": [
+                    {
+                        "i": "path",
+                        "o": "plone.app.querystring.operation.string.absolutePath",
+                        "v": "xxx::1",
+                    }
+                ],
+                "b_size": 1,
+            },
+        )
+        result = response.json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(result["error"]["message"], "No query supplied")
+
+    def test_if_absolutePath_is_invalid_and_is_not_a_objectbrowser_call_do_not_filter_by_path(
+        self,
+    ):
+        """
+        objectbrowser calls always ask for an absolutePath adn b_size == 1.
+        absolutePath is the uid of the referenced object.
+        By default Plone (querystringsearch) set /Plone as query path if absolutePath is invalid
+        """
+        response = self.api_session.post(
+            "/@querystring-search",
+            json={
+                "query": [
+                    {
+                        "i": "path",
+                        "o": "plone.app.querystring.operation.string.absolutePath",
+                        "v": "xxx::1",
+                    }
+                ],
+            },
+        )
+        result = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(result["items_total"], 2)


### PR DESCRIPTION
This patch prevents an error with objectbrowser when you have a criteria that points to a not existing UID (or no more existing). For example a listing block with a "absolutePath" criteria that points to a deleted folder.

Plone by default, in querystring, perform a catalog search through all site (/Plone) if given UID is not valid.
This is bad in objectbrowser because it made a @querystring-search call with b_size=1 to get the referenced object.
The original call, get all the site contents and returns the first one..that is not the item that we want to save inside the block.

This patch do not do any catalog search if absolutePath is invalid, and return a 400.

