### PR TITLE
Customize INameChooser adapter to check also alias ids and disallow t…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 5.4.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Customize INameChooser adapter to check also alias ids and disallow to create contents that could override aliases.
+  [cekk]
+- Add flag in controlpanel to enable/disable INameChooser customization.
+  [cekk]
 
 
 5.4.8 (2024-03-19)

--- a/src/redturtle/volto/adapters/configure.zcml
+++ b/src/redturtle/volto/adapters/configure.zcml
@@ -55,4 +55,16 @@
       zcml:condition="not-have plone-60"
       />
 
+
+    <!-- namechooser adapters -->
+    <adapter
+      factory=".namechooser.NormalizingNameChooser"
+      provides="zope.container.interfaces.INameChooser"
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      />
+    <adapter
+      factory=".namechooser.NormalizingNameChooser"
+      provides="zope.container.interfaces.INameChooser"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      />
 </configure>

--- a/src/redturtle/volto/adapters/configure.zcml
+++ b/src/redturtle/volto/adapters/configure.zcml
@@ -55,14 +55,13 @@
       zcml:condition="not-have plone-60"
       />
 
-
-    <!-- namechooser adapters -->
-    <adapter
+  <!-- namechooser adapters -->
+  <adapter
       factory=".namechooser.NormalizingNameChooser"
       provides="zope.container.interfaces.INameChooser"
       for="plone.dexterity.interfaces.IDexterityContainer"
       />
-    <adapter
+  <adapter
       factory=".namechooser.NormalizingNameChooser"
       provides="zope.container.interfaces.INameChooser"
       for="Products.CMFCore.interfaces.ISiteRoot"

--- a/src/redturtle/volto/adapters/namechooser.py
+++ b/src/redturtle/volto/adapters/namechooser.py
@@ -1,0 +1,42 @@
+from plone.app.content.namechooser import (
+    NormalizingNameChooser as BaseNormalizingNameChooser,
+)
+from plone import api
+from plone.app.redirector.interfaces import IRedirectionStorage
+from zope.component import getUtility
+from zExceptions import BadRequest
+from Acquisition import aq_inner
+from redturtle.volto import _
+from redturtle.volto.interfaces import IRedTurtleVoltoSettings
+
+
+class NormalizingNameChooser(BaseNormalizingNameChooser):
+
+    def chooseName(self, name, obj):
+        """
+        Additional check: the id should not be in redirection tool.
+        """
+        id = super().chooseName(name=name, obj=obj)
+        try:
+            if not api.portal.get_registry_record(
+                "check_aliases_in_namechooser",
+                interface=IRedTurtleVoltoSettings,
+                default=False,
+            ):
+                return id
+        except KeyError:
+            return id
+        parent = aq_inner(self.context)
+        storage = getUtility(IRedirectionStorage)
+        path = "/".join(parent.getPhysicalPath()) + "/" + id
+        if storage.get(path):
+            portal_path = "/".join(api.portal.get().getPhysicalPath())
+            fixed_path = path.replace(portal_path, "")
+            msg = _(
+                "name_chooser_alias_error",
+                default='The id "${id}" is invalid because there is already an alias for that path. '
+                'Search "${fixed_path}" in aliases management to manage it.',
+                mapping={"id": id, "fixed_path": fixed_path},
+            )
+            raise BadRequest(api.portal.translate(msg))
+        return id

--- a/src/redturtle/volto/adapters/namechooser.py
+++ b/src/redturtle/volto/adapters/namechooser.py
@@ -1,17 +1,16 @@
+from Acquisition import aq_inner
+from plone import api
 from plone.app.content.namechooser import (
     NormalizingNameChooser as BaseNormalizingNameChooser,
 )
-from plone import api
 from plone.app.redirector.interfaces import IRedirectionStorage
-from zope.component import getUtility
-from zExceptions import BadRequest
-from Acquisition import aq_inner
 from redturtle.volto import _
 from redturtle.volto.interfaces import IRedTurtleVoltoSettings
+from zExceptions import BadRequest
+from zope.component import getUtility
 
 
 class NormalizingNameChooser(BaseNormalizingNameChooser):
-
     def chooseName(self, name, obj):
         """
         Additional check: the id should not be in redirection tool.

--- a/src/redturtle/volto/interfaces.py
+++ b/src/redturtle/volto/interfaces.py
@@ -27,3 +27,16 @@ class IRedTurtleVoltoSettings(Interface):
         default=False,
         required=False,
     )
+
+    check_aliases_in_namechooser = Bool(
+        title=_(
+            "check_aliases_in_namechooser_label",
+            default="Disallow ids used in aliases",
+        ),
+        description=_(
+            "check_aliases_in_namechooser_help",
+            default="If enabled, users can't create contents with ids that are already used as aliases.",
+        ),
+        default=False,
+        required=False,
+    )

--- a/src/redturtle/volto/locales/it/LC_MESSAGES/redturtle.volto.po
+++ b/src/redturtle/volto/locales/it/LC_MESSAGES/redturtle.volto.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-03-16 14:54+0000\n"
+"POT-Creation-Date: 2024-03-21 13:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: redturtle/volto/configure.zcml:28
+#: redturtle/volto/configure.zcml:29
 msgid "Installs the redturtle.volto add-on."
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "RedTurtle Volto Settings"
 msgstr "Impostazioni RedTurtle Volto"
 
-#: redturtle/volto/configure.zcml:28
+#: redturtle/volto/configure.zcml:29
 msgid "RedTurtle: Volto"
 msgstr ""
 
-#: redturtle/volto/configure.zcml:37
+#: redturtle/volto/configure.zcml:38
 msgid "RedTurtle: Volto (uninstall)"
 msgstr ""
 
@@ -43,19 +43,34 @@ msgstr "Seleziona False per mostrare solo gli elementi non omessi dalla navigazi
 msgid "Show elements excluded from navigation"
 msgstr "Elementi omessi dalla navigazione"
 
-#: redturtle/volto/configure.zcml:37
+#: redturtle/volto/configure.zcml:38
 msgid "Uninstalls the redturtle.volto add-on."
 msgstr ""
 
+#. Default: "If enabled, users can't create contents with ids that are already used as aliases."
+#: redturtle/volto/interfaces.py:36
+msgid "check_aliases_in_namechooser_help"
+msgstr "Se attivato, alla creazione o rinomina di un contenuto, verrà eseguito anche un controllo su eventuali alias presenti (quelli visibili in Gestione URL), ed eventualmente viene impedita la creazione con quell'id."
+
+#. Default: "Disallow ids used in aliases"
+#: redturtle/volto/interfaces.py:32
+msgid "check_aliases_in_namechooser_label"
+msgstr "Controllo degli id anche sugli alias"
+
 #. Default: "If enabled, a custom ranking for SearchableText searches will be used."
-#: redturtle/volto/interfaces.py:24
+#: redturtle/volto/interfaces.py:23
 msgid "enable_advanced_query_ranking_help"
 msgstr "Se abilitato, verrà utilizzato un ranking custom per la ricerca testuale."
 
 #. Default: "Enable AdvancedQuery ranking"
-#: redturtle/volto/interfaces.py:20
+#: redturtle/volto/interfaces.py:19
 msgid "enable_advanced_query_ranking_label"
 msgstr "Abilita ranking custom con AdvancedQuery"
+
+#. Default: "The id \"${id}\" is invalid because there is already an alias for that path. Search \"${fixed_path}\" in aliases management to manage it."
+#: redturtle/volto/adapters/namechooser.py:35
+msgid "name_chooser_alias_error"
+msgstr "L'id \"${id}\" non è valido perché già utilizzato per un alias. Puoi verificarlo ed eventualmente cancellarlo, cercando \"${fixed_path}\" nella Gestione URL."
 
 #. Default: "Insert an external link directly into the field,or select an internal link clicking on the icon."
 #: redturtle/volto/types/adapters.py:25
@@ -63,11 +78,11 @@ msgid "remoteUrl_restapi_label"
 msgstr "Inserisci un link esterno direttamente nel campo, oppure seleziona un collegamento ad un contenuto del sito cliccando sull'icona accanto."
 
 #. Default: "Volto Parent URL: Content url without \"/api\"."
-#: redturtle/volto/adapters/stringinterp.py:31
+#: redturtle/volto/adapters/stringinterp.py:35
 msgid "stringinterp_volto_parent_url"
 msgstr ""
 
 #. Default: "Volto URL: Content url without \"/api\"."
-#: redturtle/volto/adapters/stringinterp.py:13
+#: redturtle/volto/adapters/stringinterp.py:18
 msgid "stringinterp_volto_url"
 msgstr "Volto URL: URL del contenuto Plone senza \"/api\"."

--- a/src/redturtle/volto/locales/redturtle.volto.pot
+++ b/src/redturtle/volto/locales/redturtle.volto.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-03-16 14:54+0000\n"
+"POT-Creation-Date: 2024-03-21 13:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: redturtle.volto\n"
 
-#: redturtle/volto/configure.zcml:28
+#: redturtle/volto/configure.zcml:29
 msgid "Installs the redturtle.volto add-on."
 msgstr ""
 
@@ -30,11 +30,11 @@ msgstr ""
 msgid "RedTurtle Volto Settings"
 msgstr ""
 
-#: redturtle/volto/configure.zcml:28
+#: redturtle/volto/configure.zcml:29
 msgid "RedTurtle: Volto"
 msgstr ""
 
-#: redturtle/volto/configure.zcml:37
+#: redturtle/volto/configure.zcml:38
 msgid "RedTurtle: Volto (uninstall)"
 msgstr ""
 
@@ -46,18 +46,33 @@ msgstr ""
 msgid "Show elements excluded from navigation"
 msgstr ""
 
-#: redturtle/volto/configure.zcml:37
+#: redturtle/volto/configure.zcml:38
 msgid "Uninstalls the redturtle.volto add-on."
 msgstr ""
 
+#. Default: "If enabled, users can't create contents with ids that are already used as aliases."
+#: redturtle/volto/interfaces.py:36
+msgid "check_aliases_in_namechooser_help"
+msgstr ""
+
+#. Default: "Disallow ids used in aliases"
+#: redturtle/volto/interfaces.py:32
+msgid "check_aliases_in_namechooser_label"
+msgstr ""
+
 #. Default: "If enabled, a custom ranking for SearchableText searches will be used."
-#: redturtle/volto/interfaces.py:24
+#: redturtle/volto/interfaces.py:23
 msgid "enable_advanced_query_ranking_help"
 msgstr ""
 
 #. Default: "Enable AdvancedQuery ranking"
-#: redturtle/volto/interfaces.py:20
+#: redturtle/volto/interfaces.py:19
 msgid "enable_advanced_query_ranking_label"
+msgstr ""
+
+#. Default: "The id \"${id}\" is invalid because there is already an alias for that path. Search \"${fixed_path}\" in aliases management to manage it."
+#: redturtle/volto/adapters/namechooser.py:35
+msgid "name_chooser_alias_error"
 msgstr ""
 
 #. Default: "Insert an external link directly into the field,or select an internal link clicking on the icon."
@@ -66,11 +81,11 @@ msgid "remoteUrl_restapi_label"
 msgstr ""
 
 #. Default: "Volto Parent URL: Content url without \"/api\"."
-#: redturtle/volto/adapters/stringinterp.py:31
+#: redturtle/volto/adapters/stringinterp.py:35
 msgid "stringinterp_volto_parent_url"
 msgstr ""
 
 #. Default: "Volto URL: Content url without \"/api\"."
-#: redturtle/volto/adapters/stringinterp.py:13
+#: redturtle/volto/adapters/stringinterp.py:18
 msgid "stringinterp_volto_url"
 msgstr ""

--- a/src/redturtle/volto/profiles/default/metadata.xml
+++ b/src/redturtle/volto/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>4303</version>
+  <version>4304</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-plone.app.caching:with-caching-proxy</dependency>

--- a/src/redturtle/volto/tests/test_namechooser_customization.py
+++ b/src/redturtle/volto/tests/test_namechooser_customization.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Setup tests for this package."""
+from redturtle.volto.testing import REDTURTLE_VOLTO_INTEGRATION_TESTING
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from zope.container.interfaces import INameChooser
+from zExceptions import BadRequest
+from redturtle.volto.interfaces import IRedTurtleVoltoSettings
+
+import unittest
+
+
+class FakeObject:
+    """"""
+
+    def __of__(self, xxx):
+        pass
+
+
+class TestNameChooserDisabled(unittest.TestCase):
+    """ """
+
+    layer = REDTURTLE_VOLTO_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        foo = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="Foo",
+        )
+
+        self.bar = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="Bar",
+        )
+
+        api.content.rename(obj=foo, new_id="xxx")
+
+    def test_by_default_customization_is_disabled_on_site_root(self):
+        """Test that we cannot choose an already created alias"""
+        fake_obj = FakeObject()
+        chooser = INameChooser(self.portal)
+
+        # can set an unused id
+        self.assertEqual("unused-id", chooser.chooseName("unused id", fake_obj))
+
+        # default behavior when trying to use an already-created id
+        self.assertEqual("bar-1", chooser.chooseName("bar", fake_obj))
+
+        # do not raise exception if the name is an alias
+        self.assertEqual("foo", chooser.chooseName("foo", fake_obj))
+
+    def test_by_default_customization_is_disabled_on_site_folderish_container(self):
+        """Test that we cannot choose an already created alias"""
+        container = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="container",
+        )
+
+        child = api.content.create(
+            container=container,
+            type="Document",
+            title="aaa",
+        )
+        api.content.create(
+            container=container,
+            type="Document",
+            title="bbb",
+        )
+
+        api.content.rename(obj=child, new_id="xxx")
+
+        fake_obj = FakeObject()
+        chooser = INameChooser(container)
+
+        # can set an unused id
+        self.assertEqual("unused-id", chooser.chooseName("unused id", fake_obj))
+
+        # default behavior when trying to use an already-created id
+        self.assertEqual("bbb-1", chooser.chooseName("bbb", fake_obj))
+
+        # do not raise exception if the name is an alias
+        self.assertEqual("aaa", chooser.chooseName("aaa", fake_obj))
+
+
+class TestNameChooserEnabled(unittest.TestCase):
+    """ """
+
+    layer = REDTURTLE_VOLTO_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        foo = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="Foo",
+        )
+
+        self.bar = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="Bar",
+        )
+
+        api.content.rename(obj=foo, new_id="xxx")
+
+        # enable it
+        api.portal.set_registry_record(
+            "check_aliases_in_namechooser", True, interface=IRedTurtleVoltoSettings
+        )
+
+    def test_name_chooser_raise_badrequest_on_site_root(self):
+        """Test that we cannot choose an already created alias"""
+        fake_obj = FakeObject()
+        chooser = INameChooser(self.portal)
+
+        # can set an unused id
+        self.assertEqual("unused-id", chooser.chooseName("unused id", fake_obj))
+
+        # default behavior when trying to use an already-created id
+        self.assertEqual("bar-1", chooser.chooseName("bar", fake_obj))
+
+        # raise exception if the name is an alias
+        with self.assertRaises(BadRequest) as cm:
+            chooser.chooseName("foo", fake_obj)
+
+        self.assertEqual(
+            'The id "foo" is invalid because there is already an alias for that path. Search "/foo" in aliases management to manage it.',
+            str(cm.exception),
+        )
+
+    def test_if_enabled_name_chooser_raise_badrequest_on_folderish_container(self):
+        """Test that we cannot choose an already created alias"""
+
+        container = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="container",
+        )
+
+        child = api.content.create(
+            container=container,
+            type="Document",
+            title="aaa",
+        )
+        api.content.create(
+            container=container,
+            type="Document",
+            title="bbb",
+        )
+
+        api.content.rename(obj=child, new_id="xxx")
+
+        fake_obj = FakeObject()
+        chooser = INameChooser(container)
+
+        # can set an unused id
+        self.assertEqual("unused-id", chooser.chooseName("unused id", fake_obj))
+
+        # can set an alias is used in another path
+        self.assertEqual("foo", chooser.chooseName("foo", fake_obj))
+
+        # default behavior when trying to use an already-created id in this context
+        self.assertEqual("bbb-1", chooser.chooseName("bbb", fake_obj))
+
+        # raise exception if the name is an alias
+        with self.assertRaises(BadRequest) as cm:
+            chooser.chooseName("aaa", fake_obj)
+
+        self.assertEqual(
+            'The id "aaa" is invalid because there is already an alias for that path. Search "/container/aaa" in aliases management to manage it.',
+            str(cm.exception),
+        )
+
+    def test_api_rename_raise_exception_if_name_is_alias(self):
+        """Test that we cannot choose an already created alias"""
+
+        item = api.content.create(
+            container=self.portal,
+            type="Document",
+            title="item",
+        )
+        with self.assertRaises(BadRequest) as cm:
+            api.content.rename(obj=item, new_id="foo", safe_id=True)
+
+        self.assertEqual(
+            'The id "foo" is invalid because there is already an alias for that path. Search "/foo" in aliases management to manage it.',
+            str(cm.exception),
+        )
+
+        # without safe_id=True, InameChooser will not be called
+        res = api.content.rename(obj=item, new_id="foo")
+        self.assertEqual(res.getId(), "foo")

--- a/src/redturtle/volto/tests/test_namechooser_customization.py
+++ b/src/redturtle/volto/tests/test_namechooser_customization.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
-from redturtle.volto.testing import REDTURTLE_VOLTO_INTEGRATION_TESTING
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from zope.container.interfaces import INameChooser
-from zExceptions import BadRequest
 from redturtle.volto.interfaces import IRedTurtleVoltoSettings
+from redturtle.volto.testing import REDTURTLE_VOLTO_INTEGRATION_TESTING
+from zExceptions import BadRequest
+from zope.container.interfaces import INameChooser
 
 import unittest
 

--- a/src/redturtle/volto/upgrades.zcml
+++ b/src/redturtle/volto/upgrades.zcml
@@ -216,7 +216,7 @@
       handler=".upgrades.to_4303"
       />
 
-    <genericsetup:upgradeStep
+  <genericsetup:upgradeStep
       title="Add new field in controlpanel"
       description=""
       profile="redturtle.volto:default"

--- a/src/redturtle/volto/upgrades.zcml
+++ b/src/redturtle/volto/upgrades.zcml
@@ -216,4 +216,12 @@
       handler=".upgrades.to_4303"
       />
 
+    <genericsetup:upgradeStep
+      title="Add new field in controlpanel"
+      description=""
+      profile="redturtle.volto:default"
+      source="4303"
+      destination="4304"
+      handler=".upgrades.update_registry"
+      />
 </configure>


### PR DESCRIPTION
…o create contents that could override aliases.

There is also a flag in registry settings that allows to enable/disable it (disabled by default).