### PR TITLE
Fix limit occurrences to 100

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.4.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed limit event occurrences to 100.
+  [eikichi18]
 
 
 5.4.9 (2024-04-22)

--- a/src/redturtle/volto/monkey.py
+++ b/src/redturtle/volto/monkey.py
@@ -105,7 +105,7 @@ def occurrences(self, range_start=None, range_end=None):
                 "Too many occurrences for %s, stopping at 100",
                 self.context.absolute_url(),
             )
-            raise StopIteration
+            return
         limit -= 1
         yield get_obj(start)
 


### PR DESCRIPTION
Il problema è che il raise poi non viene gestito. Quello che bisogna fare per fermare un generatore prematuramente è uscire dalla funzione. Poi lo StopIteration viene lanciato e gestito internamente.

Almeno secondo me questo è il modo giusto di gestire la cosa. Altrimenti bisogna gestire la StopIteration a meno in tutti i punti in cui viene chiamato quel metodo. 