### PR TITLE
Customize @@display-file to allow to download files with proper filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Changelog
   [lucabel]
 - remove newsitem template override, use default dexterity view for newsitem in backend
   [mamico]
-
+- Customize @@display-file to allow to download files with proper filename.
+  [cekk]
 
 5.5.1 (2024-07-22)
 ------------------

--- a/src/redturtle/volto/browser/configure.zcml
+++ b/src/redturtle/volto/browser/configure.zcml
@@ -66,4 +66,12 @@
       layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
       />
 
+  <!-- custom display-file -->
+  <browser:page
+      name="display-file"
+      for="*"
+      class=".display_file.DisplayFile"
+      permission="zope2.View"
+      layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
+      />
 </configure>

--- a/src/redturtle/volto/browser/display_file.py
+++ b/src/redturtle/volto/browser/display_file.py
@@ -1,0 +1,27 @@
+from plone.namedfile.browser import DisplayFile as BaseView
+from urllib.parse import quote
+
+
+class DisplayFile(BaseView):
+    """
+    Custom view
+    """
+
+    def set_headers(self, file):
+        """
+        We need to add filename to the reponse because otherwise the browser
+        use the field name as filename (last path element).
+
+        content-disposition should be "inline" to allow to display the file in the browser
+        without forcing download (with "attachment" the browser will download it).
+        """
+        super().set_headers(file=file)
+
+        filename = getattr(file, "filename", "")
+        if filename is not None:
+            if not isinstance(filename, str):
+                filename = str(filename, "utf-8", errors="ignore")
+            filename = quote(filename.encode("utf8"))
+            self.request.response.setHeader(
+                "Content-Disposition", f"inline; filename*=UTF-8''{filename}"
+            )


### PR DESCRIPTION
For example here: https://www.ausl.pc.it/it/strutture-e-territorio/dipartimenti/sanita-pubblica/prevenzione-e-sicurezza-ambienti-di-lavoro/materiali-informativi-prevenzione-e-sicurezza-negli-ambienti-di-lavoro/agenti-chimici/piano-di-promozione-e-assistenza-lavoro-rischio-salute-2013-agenti-chimici-in-metalmeccanica/@@display-file/file_principale

Without this customization, browser use "file_principale" as filename if you try to download it from the preview.