### PR TITLE
Add "type" to EXCLUDE_KEYS in blocks serializer/deserializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
   [mamico]
 - Customize @@display-file to allow to download files with proper filename.
   [cekk]
+- Add "type" to EXCLUDE_KEYS in blocks serializer/deserializer to not convert this slate attribute.
+  [cekk]
 
 5.5.1 (2024-07-22)
 ------------------

--- a/src/redturtle/volto/restapi/deserializer/blocks.py
+++ b/src/redturtle/volto/restapi/deserializer/blocks.py
@@ -9,7 +9,7 @@ from zope.component import adapter
 from zope.interface import implementer
 
 
-EXCLUDE_KEYS = ["@type", "token", "value", "@id", "query", "bg_color"]
+EXCLUDE_KEYS = ["@type", "type", "token", "value", "@id", "query", "bg_color"]
 EXCLUDE_TYPES = [
     "title",
     "listing",

--- a/src/redturtle/volto/restapi/serializer/blocks.py
+++ b/src/redturtle/volto/restapi/serializer/blocks.py
@@ -13,7 +13,7 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 
 
-EXCLUDE_KEYS = ["@type", "token", "value", "@id", "query", "bg_color"]
+EXCLUDE_KEYS = ["@type", "type", "token", "value", "@id", "query", "bg_color"]
 EXCLUDE_TYPES = [
     "title",
     "listing",


### PR DESCRIPTION
This is needed to avoid code to convert "type" slate attribute value into an internal link.

slate set something like type: "link" and i had an edge-case where "link" was a content-id, so the attribute was converted in something like: 

`type:"http://mysite.com/link"`

