### PR TITLE
Download miniatures with original filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.5.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Customize @download view to allow downloading miniature images with their original filename and not with miniature as filename.
+  [cekk]
 
 
 5.5.5 (2024-09-23)

--- a/src/redturtle/volto/browser/configure.zcml
+++ b/src/redturtle/volto/browser/configure.zcml
@@ -80,4 +80,14 @@
       permission="zope2.View"
       layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
       />
+    
+  <!-- override @@download view -->
+  <browser:page
+      name="download"
+      for="*"
+      class=".download.Download"
+      permission="zope2.View"
+      layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
+      />
+
 </configure>


### PR DESCRIPTION
Customize @download view to allow downloading miniature images with their original filename and not with miniature as filename