### PR TITLE
Remove dependency with collective.volto.cookieconsent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.5.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency with *collective.volto.cookieconsent*.
+  [cekk]
 
 
 5.5.5 (2024-09-23)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "setuptools",
-        "collective.volto.cookieconsent",  # this will be uninstalled and removed soon.
         "collective.volto.gdprcookie",
         "collective.monkeypatcher",
         "collective.purgebyid",

--- a/src/redturtle/volto/dependencies.zcml
+++ b/src/redturtle/volto/dependencies.zcml
@@ -9,7 +9,6 @@
       />
   <include package="Products.GenericSetup" />
 
-  <include package="collective.volto.cookieconsent" />
   <include package="collective.monkeypatcher" />
   <include package="collective.purgebyid" />
   <include package="kitconcept.seo" />


### PR DESCRIPTION
It is not used anymore and uninstalled several versions ago.