### PR TITLE
C'è da cambiare il nome del filename dell'sdist del pacchetto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = "\n\n".join(
 
 
 setup(
-    name="redturtle.volto",
+    name="redturtle_volto",
     version="5.6.2.dev0",
     description="Helper package to setup a RedTurtle's Plone site ready to work with Volto.",
     long_description=long_description,


### PR DESCRIPTION
PEP: <https://peps.python.org/pep-0625/>

La notifica di pypi è la seguente:

![Screenshot 2024-11-22 at 10 16 47](https://github.com/user-attachments/assets/257bd25d-2cff-4168-99ee-e7a1533abc69)


Ci ho buttato un occhio giusto per darvi una mano e per ora ho fatto solo questa modifica.

Se provo a fare un sdist ora a manina infatti il pacchetto esce:
redturtle_volto-5.6.2.dev0.tar.gz
inveche che
redturtle.volto-5.6.2.dev0.tar.gz


Però non se se poi questo vada ad incasinare altre definizioni del nome del pacchetto.

Serve un controllo di qualcuno di più esperto.
