### PR TITLE
Customize serializer for repeatableContentBlock

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Customize serialzier for repeatableContentBlock.
+  [cekk]
 
 
 5.7.0 (2025-02-06)

--- a/src/redturtle/volto/restapi/serializer/blocks.py
+++ b/src/redturtle/volto/restapi/serializer/blocks.py
@@ -14,6 +14,7 @@ from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 
+
 EXCLUDE_KEYS = ["@type", "type", "token", "value", "@id", "query", "bg_color"]
 EXCLUDE_TYPES = [
     "title",

--- a/src/redturtle/volto/restapi/serializer/configure.zcml
+++ b/src/redturtle/volto/restapi/serializer/configure.zcml
@@ -20,6 +20,10 @@
       factory=".blocks.TableResolveUIDSerializerRoot"
       provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
       />
+  <subscriber
+      factory=".blocks.RepeatableContentBlockSerializer"
+      provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
+      />
 
   <adapter factory=".dxfields.DateTimeFieldSerializer" />
   <adapter factory=".dxfields.TextLineFieldSerializer" />

--- a/src/redturtle/volto/tests/test_blocks_serializer.py
+++ b/src/redturtle/volto/tests/test_blocks_serializer.py
@@ -83,7 +83,6 @@ class TestBlocksSerializer(unittest.TestCase):
 
 
 class TestRepeatableBlockSerializer(unittest.TestCase):
-
     layer = REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
     maxDiff = None
 

--- a/src/redturtle/volto/tests/test_blocks_serializer.py
+++ b/src/redturtle/volto/tests/test_blocks_serializer.py
@@ -80,3 +80,98 @@ class TestBlocksSerializer(unittest.TestCase):
                 force_all_metadata=True
             ),
         )
+
+
+class TestRepeatableBlockSerializer(unittest.TestCase):
+
+    layer = REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
+    maxDiff = None
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.api_session = RelativeSession(self.portal_url)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        self.api_session_anon = RelativeSession(self.portal_url)
+        self.api_session_anon.headers.update({"Accept": "application/json"})
+
+        self.page_a = api.content.create(
+            container=self.portal, type="Document", title="Page A"
+        )
+
+        self.page_b = api.content.create(
+            container=self.portal, type="Document", title="Page B"
+        )
+
+        self.link = api.content.create(
+            container=self.portal,
+            type="Link",
+            title="Link",
+            remoteUrl="https://www.plone.org",
+        )
+
+        api.content.transition(obj=self.page_a, transition="publish")
+        api.content.transition(obj=self.page_b, transition="publish")
+        api.content.transition(obj=self.link, transition="publish")
+        commit()
+
+    def tearDown(self):
+        self.api_session.close()
+        self.api_session_anon.close()
+
+    def test_repeatableContentBlock_serialize_href_with_referenced_obj_for_admin(self):
+        self.page_a.blocks = {
+            "foo": {
+                "@type": "repeatableContentBlock",
+                "href": f"resolveuid/{self.page_b.UID()}",
+            },
+        }
+        commit()
+        response = self.api_session.get(self.page_a.absolute_url())
+        res = response.json()
+        self.assertEqual(res["blocks"]["foo"]["href"], self.page_b.absolute_url())
+
+    def test_repeatableContentBlock_serialize_href_with_referenced_obj_for_anon(self):
+        self.page_a.blocks = {
+            "foo": {
+                "@type": "repeatableContentBlock",
+                "href": f"resolveuid/{self.page_b.UID()}",
+            },
+        }
+        commit()
+        response = self.api_session_anon.get(self.page_a.absolute_url())
+        res = response.json()
+        self.assertEqual(res["blocks"]["foo"]["href"], self.page_b.absolute_url())
+
+    def test_repeatableContentBlock_serialize_href_with_referenced_link_obj_for_admin(
+        self,
+    ):
+        self.page_a.blocks = {
+            "foo": {
+                "@type": "repeatableContentBlock",
+                "href": f"resolveuid/{self.link.UID()}",
+            },
+        }
+        commit()
+        response = self.api_session.get(self.page_a.absolute_url())
+        res = response.json()
+        self.assertEqual(res["blocks"]["foo"]["href"], self.link.absolute_url())
+
+    def test_repeatableContentBlock_serialize_href_with_referenced_link_obj_for_anon(
+        self,
+    ):
+        self.page_a.blocks = {
+            "foo": {
+                "@type": "repeatableContentBlock",
+                "href": f"resolveuid/{self.link.UID()}",
+            },
+        }
+        commit()
+        response = self.api_session_anon.get(self.page_a.absolute_url())
+        res = response.json()
+        self.assertEqual(res["blocks"]["foo"]["href"], self.link.absolute_url())


### PR DESCRIPTION
To prevent resolve links when referenced object is a Link.

This is needed because if we want to show infos of the Link (like its image), we need to keep href attribute as Link obj url.
Without this customization, the href attribute will be converted in Link's remoteURL address