### PR TITLE
Fix rss feed image selection, now it uses the correct field for preview_image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.8.1 (unreleased)
 ------------------
 
+- Fix rss feed image selection, now it uses the correct field for preview_image.
+  [mamico]
+  
 - Fix issue with event search in @querystring-search override:
   converting a timezone-aware DateTime to utcdatetime causes a problem when searching for
   "today", as it shifts start=day x at 00:00 to start=day x-1 at 22:00 in GMT+2 timezone.

--- a/src/redturtle/volto/adapters/rss.py
+++ b/src/redturtle/volto/adapters/rss.py
@@ -59,14 +59,14 @@ class CustomFeedItem(DexterityItem):
         if img_choice == "preview_image" and self._has_valid_image(
             preview, "preview_image"
         ):
-            self.file = preview.image
+            self.file = preview.preview_image
             self.field_name = "preview_image"
         elif img_choice == "image" and self._has_valid_image(lead, "image"):
             self.file = lead.image
             self.field_name = "image"
         elif img_choice == "listing_like":
             if self._has_valid_image(preview, "preview_image"):
-                self.file = preview.image
+                self.file = preview.preview_image
                 self.field_name = "preview_image"
             elif self._has_valid_image(lead, "image"):
                 self.file = lead.image

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -243,7 +243,7 @@ class QuerystringSearch(BaseQuerystringSearch):
 
     def get_datetime_value(self, value):
         if isinstance(value, DateTime):
-            # return value.utcdatetime()
+            # return value.utcdatetime()
             # manteniamo il possibile timezone
             return value.asdatetime()
         return datetime.fromisoformat(value)


### PR DESCRIPTION
When the RSS is used with rssseervce/rssmixer the enclousre mimetype is not found