### PR TITLE
Set a default view for Plone Site different by default_view because i…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11"]
+        # python: ["3.8", "3.9", "3.10", "3.11"]
+        # plone: ["52", "60"]
+        python: ["3.11"]
         plone: ["60"]
         tz: ["UTC", "Europe/Rome"]
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Changelog
 
 5.5.13 (unreleased)
 -------------------
+5.9.1 (unreleased)
+------------------
+- Exclude "teaser" to aavoid block mmodification by resolveuidseriializer
+  [mamico]
+- Fix in resolveuid serializer if block is not a dict nor dict-like 
+  [mamico]
+- Make querystringsearch endpoint more customizable: now custom_query is defined in a separate method.
+  [cekk]
+- fix file:/// as external link in summary
+  [mamico]
+- Set a default view for Plone Site different by default_view because in plone.restapi 9.15.2 is exposed and we don't need it because it broke agid layout.
+  [cekk]
 
 - Nothing changed yet.
 

--- a/src/redturtle/volto/browser/configure.zcml
+++ b/src/redturtle/volto/browser/configure.zcml
@@ -96,4 +96,13 @@
       permission="zope2.View"
       layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
       />
+
+  <browser:page
+      name="homepage_view"
+      for="plone.base.interfaces.IPloneSiteRoot"
+      class="plone.app.dexterity.browser.folder_listing.FolderView"
+      template="templates/homepage_view.pt"
+      permission="zope2.View"
+      layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
+      />
 </configure>

--- a/src/redturtle/volto/browser/templates/homepage_view.pt
+++ b/src/redturtle/volto/browser/templates/homepage_view.pt
@@ -1,0 +1,119 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:tal="http://xml.zope.org/namespaces/tal" lang="en" metal:use-macro="context/@@main_template/macros/master" xml:lang="en" i18n:domain="plone">
+    <body>
+
+        <metal:content-core fill-slot="content-core">
+            <metal:block define-macro="content-core">
+
+                <metal:listingmacro define-macro="listing">
+                    <tal:results define="
+                         batch view/batch;
+                       ">
+                        <tal:listing condition="batch">
+                            <div class="entries" metal:define-slot="entries">
+                                <tal:repeat metal:define-macro="entries" repeat="item batch">
+                                    <tal:block tal:define="
+                               obj item/getObject;
+                               item_url item/getURL;
+                               item_id item/getId;
+                               item_title item/Title;
+                               item_description item/Description;
+                               item_type item/PortalType;
+                               item_modified item/ModificationDate;
+                               item_created item/CreationDate;
+                               item_type_class python:'contenttype-' + view.normalizeString(item_type);
+                               item_wf_state item/review_state;
+                               item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
+                               item_creator item/Creator;
+                               item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;
+                               item_has_image python:item.getIcon;
+                             ">
+                                        <metal:block define-slot="entry">
+                                            <article class="entry">
+                                                <header metal:define-macro="listitem">
+                                                    <span class="summary" tal:attributes="
+                                  title item_type;
+                                ">
+                                                        <a tal:attributes="
+                                 href item_link;
+                               ">
+                                                            <img class="image-tile" tal:condition="item_has_image" tal:attributes="
+                                     src  string:$item_url/@@images/image/tile;
+                                   " />
+                                                        </a>
+                                                        <a tal:content="python: item_title or item_id" tal:attributes="
+                                 href item_link;
+                                 class string:$item_type_class $item_wf_state_class url;
+                                 title item_type;
+                               ">
+
+                             Item Title
+                                                        </a>
+                                                    </span>
+                                                    <metal:block metal:define-macro="document_byline">
+                                                        <div class="documentByLine">
+                                                            <tal:byline condition="view/show_about">
+                          &mdash;
+                                                                <tal:name tal:define="
+                                            author python:view.pas_member.info(item_creator);
+                                            creator_short_form author/username;
+                                            creator_long_form string:?author=${author/username};
+                                            creator_is_openid python:'/' in creator_short_form;
+                                            creator_id python:(creator_short_form, creator_long_form)[creator_is_openid];
+                                          " tal:condition="item_creator">
+                                                                    <span i18n:translate="label_by_author">
+                            by
+                                                                        <a tal:content="author/name_or_id" tal:omit-tag="not:author" tal:attributes="
+                                         href string:${view/navigation_root_url}/author/${item_creator};
+                                       " i18n:name="author">
+                              Bob Dobalina
+                                                                        </a>
+                                                                    </span>
+                                                                </tal:name>
+
+                                                                <tal:modified>
+                            &mdash;
+                                                                    <tal:mod i18n:translate="box_last_modified">last modified</tal:mod>
+                                                                    <span tal:replace="python:view.toLocalizedTime(item_modified,long_format=1)">
+                              August 16, 2001 at 23:35:59
+                                                                    </span>
+                                                                </tal:modified>
+
+                                                                <metal:description define-slot="description_slot">
+                                                                    <tal:comment replace="nothing">
+                              Place custom listing info for custom types here
+                                                                    </tal:comment>
+                                                                </metal:description>
+                                                            </tal:byline>
+                                                        </div>
+                                                    </metal:block>
+                                                </header>
+                                                <p class="description discreet" tal:condition="item_description" tal:content="item_description">
+                    description
+                                                </p>
+                                            </article>
+                                        </metal:block>
+                                    </tal:block>
+                                </tal:repeat>
+                            </div>
+
+                            <div metal:use-macro="context/batch_macros/macros/navigation"></div>
+
+                        </tal:listing>
+
+                        <metal:empty metal:define-slot="no_items_in_listing">
+                            <p class="discreet" tal:condition="not: view/batch" tal:content="view/no_items_message">
+          There are currently no items in this folder.
+                            </p>
+                        </metal:empty>
+
+                    </tal:results>
+                </metal:listingmacro>
+
+            </metal:block>
+        </metal:content-core>
+
+    </body>
+</html>

--- a/src/redturtle/volto/profiles/default/metadata.xml
+++ b/src/redturtle/volto/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>4308</version>
+  <version>4309</version>
   <dependencies>
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-plone.app.caching:with-caching-proxy</dependency>

--- a/src/redturtle/volto/profiles/default/types/Plone_Site.xml
+++ b/src/redturtle/volto/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object
+    i18n:domain="plone"
+    meta_type="Dexterity FTI"
+    name="Plone Site"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  
+  <property name="behaviors" purge="false">
+    <element value="kitconcept.seo" />
+  </property>
+
+  <!--
+    these are needed because plone.restapi 9.15.2 add layout to SiteRoot serializer.
+    This will broke agid-like themese because will render also title and description in homepage
+  -->
+  <property name="default_view">homepage_view</property>
+  <property name="immediate_view">homepage_view</property> 
+</object>
+ 

--- a/src/redturtle/volto/upgrades.py
+++ b/src/redturtle/volto/upgrades.py
@@ -594,3 +594,9 @@ def to_4308(context):
     logger.info(f"Reindex complete. Reindexed {len(reindexed)} contents:")
     for url in reindexed:
         logger.info(f"- {url}")
+
+
+def to_4309(context):
+    portal_types = api.portal.get_tool(name="portal_types")
+    portal_types["Plone Site"].default_view = "homepage_view"
+    portal_types["Plone Site"].immediate_view = "homepage_view"

--- a/src/redturtle/volto/upgrades.zcml
+++ b/src/redturtle/volto/upgrades.zcml
@@ -256,4 +256,12 @@
       destination="4308"
       handler=".upgrades.to_4308"
       />
+  <genericsetup:upgradeStep
+      title="Set default and immediate view for Plone Site"
+      description=""
+      profile="redturtle.volto:default"
+      source="4308"
+      destination="4309"
+      handler=".upgrades.to_4309"
+      />
 </configure>

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -1,7 +1,7 @@
 [buildout]
 
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-5.2.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/refs/heads/master/test-5.2.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
 

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -1,7 +1,7 @@
 [buildout]
 
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-6.0.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/refs/heads/master/test-6.0.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     https://raw.githubusercontent.com/RedTurtle/iocomune-backend/main/versions.cfg
     base.cfg


### PR DESCRIPTION
backport #146 

* Set a default view for Plone Site different by default_view because in plone.restapi 9.15.2, layout is exposed and we don't need it because it broke agid layout