### PR TITLE
Us 69847

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Fix bug search event restapi (#148)
   [mamico]
+- Added new service to list blocks types and where are used.
+  [daniele]
 
 
 5.9.3 (2025-11-24)

--- a/src/redturtle/volto/restapi/services/blocks/configure.zcml
+++ b/src/redturtle/volto/restapi/services/blocks/configure.zcml
@@ -1,0 +1,21 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    >
+
+  <plone:service
+      method="GET"
+      factory=".get.BlocksGet"
+      for="zope.interface.Interface"
+      permission="zope2.View"
+      layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
+      name="@blocks-list"
+      />
+
+  <cache:ruleset
+      for=".get.BlocksGet"
+      ruleset="plone.content.dynamic"
+      />
+
+</configure>

--- a/src/redturtle/volto/restapi/services/blocks/get.py
+++ b/src/redturtle/volto/restapi/services/blocks/get.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from plone.dexterity.interfaces import IDexterityContainer
+from plone.restapi.services import Service
+from zope.component import adapter
+from zope.interface import Interface
+from plone import api
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import getMultiAdapter
+import json
+
+# @adapter(IDexterityContainer, Interface)
+# class BlocksHandler(object):
+#     def __init__(self, context, request):
+#         self.context = context
+#         self.request = request
+
+#     def __call__(self):
+#         import pdb;pdb.set_trace()
+
+#         catalog = api.portal.get_tool("portal_catalog")
+#         zcatalog = catalog._catalog
+
+#         blocks_index = zcatalog.getIndex("block_types")
+#         data_indexed = blocks_index._index
+
+#         results = {}
+
+#         for docids in data_indexed.values():
+#             for docid in docids:
+#                 zcinfo = zcatalog.getIndexDataForRID(docid)
+#                 for btype in zcinfo.get("block_types", []):
+#                     tmp_list = results.get(btype, [])
+#                     brain_path = zcinfo.get("path", "")
+#                     if brain_path not in tmp_list:
+#                         tmp_list.append(brain_path)
+
+#                     results.update({btype: tmp_list})
+
+#         import pdb;pdb.set_trace()
+
+#         #results = getMultiAdapter((results, self.request), ISerializeToJson)()
+#         return results
+    
+#         # for key, value in data_indexed.iteritems():
+#         #     for item in value.values():
+#         #         pass
+#         #     #results.update(key: "")
+
+
+#         # brains = catalog(index="block_types")
+#         # if not brains:
+#         #     return
+
+#         # for brain in brains:
+
+
+
+class BlocksGet(Service):
+    def reply(self):
+        catalog = api.portal.get_tool("portal_catalog")
+        zcatalog = catalog._catalog
+
+        blocks_index = zcatalog.getIndex("block_types")
+        data_indexed = blocks_index._index
+
+        results = {}
+
+        for docids in data_indexed.values():
+            for docid in docids:
+                zcinfo = zcatalog.getIndexDataForRID(docid)
+                for btype in zcinfo.get("block_types", []):
+                    tmp_list = results.get(btype, [])
+                    brain_path = zcinfo.get("path", "")
+                    if brain_path not in tmp_list:
+                        tmp_list.append(brain_path)
+
+                    results.update({btype: tmp_list})
+
+        return json.dumps(results)
+    

--- a/src/redturtle/volto/restapi/services/configure.zcml
+++ b/src/redturtle/volto/restapi/services/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     >
 
+  <include package=".blocks" />
   <include package=".copymove" />
   <include package=".navigation" />
   <include package=".querystringsearch" />


### PR DESCRIPTION
The idea is to provide a data mapping like the one provided by the manage_browse view when inspecting an index from ZMI:

```
listing  [/Plone/it/pagina]

slate 	 [/Plone]

title 	 [/Plone/it/pagina]
         [/Plone]
```

Some further checks need to be implmented but it's a starting point to avoid poor performances when the rest view is called.