### PR TITLE
use ``api.content.get`` instead of ``restrictedTraverse`` in ``RelatonChoiceFieldDeserializer`` to prevent type confusion via path/URL resolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.9.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Security fix: use ``api.content.get`` instead of ``restrictedTraverse`` in ``RelationChoiceFieldDeserializer`` to prevent type confusion via path/URL resolution
+  [mamico]
 
 
 5.9.4 (2025-12-05)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 import os
 import sys
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 from setuptools import find_packages
 from setuptools import setup
 
-
 long_description = "\n\n".join(
     [
         open("README.rst").read(),

--- a/src/redturtle/volto/__init__.py
+++ b/src/redturtle/volto/__init__.py
@@ -4,7 +4,6 @@ from plone.app.dexterity.textindexer import utils
 from redturtle.volto import patches  # noqa
 from zope.i18nmessageid import MessageFactory
 
-
 _ = MessageFactory("redturtle.volto")
 
 # Index also subjects in SearchableText.

--- a/src/redturtle/volto/adapters/rss.py
+++ b/src/redturtle/volto/adapters/rss.py
@@ -9,7 +9,6 @@ from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.volto.behaviors.preview import IPreview
 from redturtle.volto.interfaces import ICustomFeedItem
 
-
 try:
     from plone.base.interfaces.syndication import IFeed
 except ModuleNotFoundError:

--- a/src/redturtle/volto/adapters/stringinterp.py
+++ b/src/redturtle/volto/adapters/stringinterp.py
@@ -4,7 +4,6 @@ from Products.CMFCore.interfaces import IContentish
 from redturtle.volto import _
 from zope.component import adapter
 
-
 try:
     from plone.stringinterp import _ as stringinterp_mf
 except ImportError:

--- a/src/redturtle/volto/browser/find_blocks.py
+++ b/src/redturtle/volto/browser/find_blocks.py
@@ -9,7 +9,6 @@ from zope.schema import getFieldsInOrder
 import json
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 BLOCKS = [

--- a/src/redturtle/volto/browser/find_broken_links.py
+++ b/src/redturtle/volto/browser/find_broken_links.py
@@ -6,7 +6,6 @@ from Products.Five import BrowserView
 from six import StringIO
 from zope.schema import getFieldsInOrder
 
-
 try:
     from collective.volto.blocksfield.field import BlocksField
 
@@ -16,7 +15,6 @@ except ImportError:
 
 import csv
 import logging
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/redturtle/volto/browser/fix_links.py
+++ b/src/redturtle/volto/browser/fix_links.py
@@ -13,7 +13,6 @@ import json
 import logging
 import re
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/redturtle/volto/config/__init__.py
+++ b/src/redturtle/volto/config/__init__.py
@@ -1,4 +1,3 @@
 import os
 
-
 MAX_LIMIT = int(os.environ.get("REDTURTLE_VOLTO_MAX_LIMIT_SEARCH") or 500)

--- a/src/redturtle/volto/indexers.py
+++ b/src/redturtle/volto/indexers.py
@@ -8,7 +8,6 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 
-
 try:
     from plone.base.utils import safe_text
 except ImportError:

--- a/src/redturtle/volto/locales/update.py
+++ b/src/redturtle/volto/locales/update.py
@@ -4,7 +4,6 @@ import os
 import pkg_resources
 import subprocess
 
-
 domain = "redturtle.volto"
 os.chdir(pkg_resources.resource_filename(domain, ""))
 os.chdir("../../../")

--- a/src/redturtle/volto/monkey.py
+++ b/src/redturtle/volto/monkey.py
@@ -20,7 +20,6 @@ import datetime
 import logging
 import os
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/redturtle/volto/patches.py
+++ b/src/redturtle/volto/patches.py
@@ -16,7 +16,6 @@ from ZTUtils.Lazy import LazyMap
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 _ = MessageFactory("plone")

--- a/src/redturtle/volto/restapi/deserializer/blocks.py
+++ b/src/redturtle/volto/restapi/deserializer/blocks.py
@@ -8,7 +8,6 @@ from redturtle.volto.interfaces import IRedturtleVoltoLayer
 from zope.component import adapter
 from zope.interface import implementer
 
-
 EXCLUDE_KEYS = ["@type", "type", "token", "value", "@id", "query", "bg_color"]
 EXCLUDE_TYPES = [
     "title",

--- a/src/redturtle/volto/restapi/deserializer/relationfield.py
+++ b/src/redturtle/volto/restapi/deserializer/relationfield.py
@@ -1,3 +1,4 @@
+from plone import api
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.deserializer.dxfields import DefaultFieldDeserializer
 from plone.restapi.interfaces import IFieldDeserializer
@@ -6,7 +7,6 @@ from redturtle.volto.interfaces import IRedturtleVoltoLayer
 from urllib.parse import urlparse
 from z3c.relationfield.interfaces import IRelationChoice
 from zope.component import adapter
-from zope.component import getMultiAdapter
 from zope.component import queryUtility
 from zope.interface import implementer
 from zope.intid.interfaces import IIntIds
@@ -30,17 +30,14 @@ class RelationChoiceFieldDeserializer(DefaultFieldDeserializer):
             obj = intids.queryObject(value)
             resolved_by = "intid"
         elif isinstance(value, str):
-            portal = getMultiAdapter(
-                (self.context, self.request), name="plone_portal_state"
-            ).portal()
-            portal_url = portal.absolute_url()
+            portal_url = api.portal.get().absolute_url()
             if value.startswith(portal_url):
                 # Resolve by URL
-                obj = portal.restrictedTraverse(urlparse(value).path.lstrip("/"), None)
+                obj = api.content.get(path=urlparse(value).path)
                 resolved_by = "URL"
             elif value.startswith("/"):
                 # Resolve by path
-                obj = portal.restrictedTraverse(value.lstrip("/"), None)
+                obj = api.content.get(path=value)
                 resolved_by = "path"
             else:
                 # Resolve by UID

--- a/src/redturtle/volto/restapi/serializer/blocks.py
+++ b/src/redturtle/volto/restapi/serializer/blocks.py
@@ -14,7 +14,6 @@ from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 
-
 EXCLUDE_KEYS = ["@type", "type", "token", "value", "@id", "query", "bg_color"]
 EXCLUDE_TYPES = [
     "title",

--- a/src/redturtle/volto/restapi/serializer/dxfields.py
+++ b/src/redturtle/volto/restapi/serializer/dxfields.py
@@ -15,7 +15,6 @@ from zope.schema.interfaces import ITextLine
 
 import re
 
-
 RESOLVEUID_RE = re.compile(".*?/resolve[Uu]id/([^/]*)/?(.*)$")
 
 

--- a/src/redturtle/volto/restapi/serializer/summary.py
+++ b/src/redturtle/volto/restapi/serializer/summary.py
@@ -14,7 +14,6 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
 
-
 EMPTY_STRINGS = ["None"]
 
 

--- a/src/redturtle/volto/restapi/services/querystringsearch/get.py
+++ b/src/redturtle/volto/restapi/services/querystringsearch/get.py
@@ -22,7 +22,6 @@ from zope.component import getMultiAdapter
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/redturtle/volto/restapi/services/search/get.py
+++ b/src/redturtle/volto/restapi/services/search/get.py
@@ -10,7 +10,6 @@ from zope.component import getMultiAdapter
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 # search for 'ranking' in 'SearchableText' and rank very high

--- a/src/redturtle/volto/setuphandlers.py
+++ b/src/redturtle/volto/setuphandlers.py
@@ -5,7 +5,6 @@ from zope.interface import implementer
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/redturtle/volto/tests/test_blocks_linkintegrity.py
+++ b/src/redturtle/volto/tests/test_blocks_linkintegrity.py
@@ -10,7 +10,6 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 import unittest
 
-
 HAS_PLONE_6 = getattr(
     import_module("Products.CMFPlone.factory"), "PLONE60MARKER", False
 )

--- a/src/redturtle/volto/tests/test_content_types.py
+++ b/src/redturtle/volto/tests/test_content_types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME

--- a/src/redturtle/volto/tests/test_ct_link.py
+++ b/src/redturtle/volto/tests/test_ct_link.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME

--- a/src/redturtle/volto/tests/test_dxfield_deserializer.py
+++ b/src/redturtle/volto/tests/test_dxfield_deserializer.py
@@ -78,6 +78,25 @@ class TestDXFieldDeserializer(unittest.TestCase):
 
         self.assertIsNone(value)
 
+    def test_relationlist_deserialization_correct_with_url(self):
+        login(self.portal, "user1")
+
+        value = self.deserialize(
+            "relatedItems",
+            [self.portal.doc1.absolute_url()],
+        )
+
+        self.assertTrue(value)
+
+    def test_relationlist_rejects_non_content_object_by_path(self):
+        login(self.portal, "user1")
+
+        with self.assertRaises(ValueError):
+            self.deserialize(
+                "relatedItems",
+                ["/plone/portal_catalog"],
+            )
+
     def test_relationlist_deserialization_correct_with_uid(self):
         # documents
         doc2 = self.portal.folder.otherfolder[

--- a/src/redturtle/volto/tests/test_dxfield_deserializer.py
+++ b/src/redturtle/volto/tests/test_dxfield_deserializer.py
@@ -50,7 +50,7 @@ class TestDXFieldDeserializer(unittest.TestCase):
         )
         return deserializer(value)
 
-    def test_relationlist_deserialization_broke_with_path(self):
+    def test_relationlist_deserialization_correct_with_path(self):
         # documents
         doc2 = self.portal.folder.otherfolder[
             self.portal.folder.otherfolder.invokeFactory(
@@ -65,18 +65,17 @@ class TestDXFieldDeserializer(unittest.TestCase):
         ]
         self.wftool.doActionFor(self.portal.folder.otherfolder.doc3, "publish")
 
+        transaction.commit()
+
         setRoles(self.portal, TEST_USER_ID, ["Member"])
         login(self.portal, TEST_USER_NAME)
 
-        try:
-            value = self.deserialize(
-                "relatedItems",
-                [str(doc2.absolute_url_path()), str(doc3.absolute_url_path())],
-            )
-        except ValueError:
-            value = None
+        value = self.deserialize(
+            "relatedItems",
+            [str(doc2.absolute_url_path()), str(doc3.absolute_url_path())],
+        )
 
-        self.assertIsNone(value)
+        self.assertTrue(value)
 
     def test_relationlist_deserialization_correct_with_url(self):
         login(self.portal, "user1")

--- a/src/redturtle/volto/tests/test_namechooser_customization.py
+++ b/src/redturtle/volto/tests/test_namechooser_customization.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID

--- a/src/redturtle/volto/tests/test_patch_absolutize_path.py
+++ b/src/redturtle/volto/tests/test_patch_absolutize_path.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID

--- a/src/redturtle/volto/tests/test_rss.py
+++ b/src/redturtle/volto/tests/test_rss.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from redturtle.volto.adapters.rss import CustomFeedItem
 from redturtle.volto.interfaces import ICustomFeedItem
-
 
 try:
     from plone.base.interfaces.syndication import IFeed

--- a/src/redturtle/volto/tests/test_setup.py
+++ b/src/redturtle/volto/tests/test_setup.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from redturtle.volto.testing import REDTURTLE_VOLTO_INTEGRATION_TESTING  # noqa: E501
 
 import unittest
-
 
 try:
     from Products.CMFPlone.utils import get_installer

--- a/src/redturtle/volto/types/adapters.py
+++ b/src/redturtle/volto/types/adapters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """JsonSchema providers."""
+
 from plone.restapi.types.adapters import TextLineJsonSchemaProvider as Base
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from redturtle.volto import _

--- a/src/redturtle/volto/upgrades.py
+++ b/src/redturtle/volto/upgrades.py
@@ -13,7 +13,6 @@ from redturtle.volto.setuphandlers import remove_custom_googlebot
 from uuid import uuid4
 from zope.schema import getFields
 
-
 try:
     from plone.base.utils import get_installer
 except Exception:
@@ -22,7 +21,6 @@ except Exception:
 import json
 import logging
 import transaction
-
 
 try:
     from collective.volto.blocksfield.field import BlocksField


### PR DESCRIPTION
[src/redturtle/volto/restapi/deserializer/relationfield.py](https://github.com/RedTurtle/redturtle.volto/pull/157/changes#diff-c5ffc7f5bc92208fc19322ca7544d08544be70268fbf0529903a57d8f73b7d0f)

[src/redturtle/volto/tests/test_dxfield_deserializer.py](https://github.com/RedTurtle/redturtle.volto/pull/157/changes#diff-9008ba378a87a1f6ca39fb7400aecd6d831dba9e0a9e7f592e9c41b3dffdfdf0)
