### PR TITLE
override the 404 page with a blank one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Security fix: use ``api.content.get`` instead of ``restrictedTraverse`` in ``RelationChoiceFieldDeserializer`` to prevent type confusion via path/URL resolution
   [mamico]
-- Serve a minimal standalone 404 page for HTML requests that hit the backend directly instead of Volto, overriding Plone's themed error page.
+- Serve a minimal standalone 404 page for HTML requests that hit the backend directly instead of Volto, overriding Plone's themed error page. The page text is translatable (Italian translation included).
   [fedevancin]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Security fix: use ``api.content.get`` instead of ``restrictedTraverse`` in ``RelationChoiceFieldDeserializer`` to prevent type confusion via path/URL resolution
   [mamico]
-- Serve a minimal standalone 404 page for HTML requests that hit the backend directly instead of Volto, overriding Plone's themed error page. The page text is translatable (Italian translation included).
+- Serve a minimal standalone 404 page for HTML requests that hit the backend directly instead of Volto, overriding Plone's themed error page and disabling the site theme so it renders even when the frontend/theme assets are unreachable. The page text is translatable (Italian translation included).
   [fedevancin]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Security fix: use ``api.content.get`` instead of ``restrictedTraverse`` in ``RelationChoiceFieldDeserializer`` to prevent type confusion via path/URL resolution
   [mamico]
+- Serve a minimal standalone 404 page for HTML requests that hit the backend directly instead of Volto, overriding Plone's themed error page.
+  [fedevancin]
 
 
 5.9.5 (2026-06-18)
@@ -40,7 +42,7 @@ Changelog
 ------------------
 - Exclude "teaser" to avoid block modification by resolveuidserializer
   [mamico]
-- Fix in resolveuid serializer if block is not a dict nor dict-like 
+- Fix in resolveuid serializer if block is not a dict nor dict-like
   [mamico]
 - Make querystringsearch endpoint more customizable: now custom_query is defined in a separate method.
   [cekk]

--- a/src/redturtle/volto/browser/configure.zcml
+++ b/src/redturtle/volto/browser/configure.zcml
@@ -107,4 +107,16 @@
       permission="zope2.View"
       layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
       />
+
+  <!-- Simple, standalone 404 page for requests that hit the backend
+       directly instead of Volto (e.g. haproxy misrouting), replacing
+       Plone's themed error page which depends on frontend assets. -->
+  <browser:page
+      name="index.html"
+      for="zExceptions.NotFound"
+      class=".notfound.NotFound"
+      template="templates/notfound.pt"
+      permission="zope.Public"
+      layer="redturtle.volto.interfaces.IRedturtleVoltoLayer"
+      />
 </configure>

--- a/src/redturtle/volto/browser/notfound.py
+++ b/src/redturtle/volto/browser/notfound.py
@@ -1,0 +1,37 @@
+from plone.memoize.view import memoize
+from Products.Five import BrowserView
+from zope.component import getMultiAdapter
+
+import json
+
+
+class NotFound(BrowserView):
+    """Render a minimal, standalone 404 page.
+
+    Overrides Plone's themed error page (which relies on frontend assets)
+    for requests that hit this backend directly instead of Volto, e.g. an
+    haproxy misconfiguration routing there instead of to the frontend.
+    """
+
+    @property
+    @memoize
+    def plone_redirector_view(self):
+        return getMultiAdapter(
+            (self.__parent__, self.request), name="plone_redirector_view"
+        )
+
+    def __call__(self):
+        request = self.request
+
+        if self.plone_redirector_view.attempt_redirect():
+            # a redirect is possible: attempt_redirect already set the
+            # Location header and status on the response.
+            return ""
+
+        request.response.setStatus(404)
+
+        if "text/html" not in request.getHeader("Accept", ""):
+            request.response.setHeader("Content-Type", "application/json")
+            return json.dumps({"error_type": "NotFound"})
+
+        return self.index()

--- a/src/redturtle/volto/browser/notfound.py
+++ b/src/redturtle/volto/browser/notfound.py
@@ -1,4 +1,3 @@
-from plone.memoize.view import memoize
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 

--- a/src/redturtle/volto/browser/notfound.py
+++ b/src/redturtle/volto/browser/notfound.py
@@ -27,6 +27,10 @@ class NotFound(BrowserView):
             return ""
 
         request.response.setStatus(404)
+        # Never let the site theme wrap this page: it must stay
+        # renderable even when the frontend/theme assets are unreachable,
+        # which is the whole point of this view.
+        request.response.setHeader("X-Theme-Disabled", "1")
 
         if "text/html" not in request.getHeader("Accept", ""):
             request.response.setHeader("Content-Type", "application/json")

--- a/src/redturtle/volto/browser/notfound.py
+++ b/src/redturtle/volto/browser/notfound.py
@@ -14,7 +14,6 @@ class NotFound(BrowserView):
     """
 
     @property
-    @memoize
     def plone_redirector_view(self):
         return getMultiAdapter(
             (self.__parent__, self.request), name="plone_redirector_view"

--- a/src/redturtle/volto/browser/templates/notfound.pt
+++ b/src/redturtle/volto/browser/templates/notfound.pt
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="redturtle.volto"
+      lang="en"
+      tal:attributes="lang request/LANGUAGE | string:en">
 <head>
   <meta charset="utf-8" />
-  <title>Page not found</title>
+  <title i18n:translate="">Page not found</title>
 </head>
 <body>
   <div class="notfound">
-    <h1>404 - Page not found</h1>
-    <p>
+    <h1 i18n:translate="">404 - Page not found</h1>
+    <p i18n:translate="">
       The page you are looking for does not exist.
     </p>
   </div>

--- a/src/redturtle/volto/browser/templates/notfound.pt
+++ b/src/redturtle/volto/browser/templates/notfound.pt
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Page not found</title>
+</head>
+<body>
+  <div class="notfound">
+    <h1>404 - Page not found</h1>
+    <p>
+      The page you are looking for does not exist.
+    </p>
+  </div>
+</body>
+</html>

--- a/src/redturtle/volto/locales/it/LC_MESSAGES/redturtle.volto.po
+++ b/src/redturtle/volto/locales/it/LC_MESSAGES/redturtle.volto.po
@@ -14,6 +14,10 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "404 - Page not found"
+msgstr "404 - Pagina non trovata"
+
 #: redturtle/volto/patches.py:62
 msgid "Alternative url path must not be a view."
 msgstr ""
@@ -33,6 +37,10 @@ msgstr "Installa il componente aggiuntivo redturtle.volto."
 #: redturtle/volto/profiles/default/registry/criteria.xml
 msgid "Metadata"
 msgstr "Metadati"
+
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "Page not found"
+msgstr "Pagina non trovata"
 
 #: redturtle/volto/browser/controlpanel.py:11
 #: redturtle/volto/profiles/default/controlpanel.xml
@@ -70,6 +78,10 @@ msgstr ""
 #: redturtle/volto/patches.py:59
 msgid "Target path must start with a slash."
 msgstr ""
+
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "The page you are looking for does not exist."
+msgstr "La pagina che stai cercando non esiste."
 
 #: redturtle/volto/patches.py:74
 msgid "The provided alternative url already exists!"

--- a/src/redturtle/volto/locales/redturtle.volto.pot
+++ b/src/redturtle/volto/locales/redturtle.volto.pot
@@ -17,6 +17,10 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: redturtle.volto\n"
 
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "404 - Page not found"
+msgstr ""
+
 #: redturtle/volto/patches.py:62
 msgid "Alternative url path must not be a view."
 msgstr ""
@@ -35,6 +39,10 @@ msgstr ""
 
 #: redturtle/volto/profiles/default/registry/criteria.xml
 msgid "Metadata"
+msgstr ""
+
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "Page not found"
 msgstr ""
 
 #: redturtle/volto/browser/controlpanel.py:11
@@ -72,6 +80,10 @@ msgstr ""
 
 #: redturtle/volto/patches.py:59
 msgid "Target path must start with a slash."
+msgstr ""
+
+#: redturtle/volto/browser/templates/notfound.pt
+msgid "The page you are looking for does not exist."
 msgstr ""
 
 #: redturtle/volto/patches.py:74

--- a/src/redturtle/volto/testing.py
+++ b/src/redturtle/volto/testing.py
@@ -18,7 +18,6 @@ import plone.restapi
 import plone.volto
 import redturtle.volto
 
-
 # bin/test (zc.recipe.testrunner) doesn't set this, unlike the zope instance
 # (see base.cfg), so .po files never get compiled to .mo and translations
 # are never available unless we set it here before the layers below load ZCML.

--- a/src/redturtle/volto/testing.py
+++ b/src/redturtle/volto/testing.py
@@ -12,10 +12,17 @@ import collective.volto.gdprcookie
 import collective.volto.sitesettings
 import experimental.noacquisition
 import kitconcept.seo
+import os
 import plone.app.caching
 import plone.restapi
 import plone.volto
 import redturtle.volto
+
+
+# bin/test (zc.recipe.testrunner) doesn't set this, unlike the zope instance
+# (see base.cfg), so .po files never get compiled to .mo and translations
+# are never available unless we set it here before the layers below load ZCML.
+os.environ.setdefault("zope_i18n_compile_mo_files", "true")
 
 
 class RedturtleVoltoLayer(PloneSandboxLayer):

--- a/src/redturtle/volto/tests/test_notfound.py
+++ b/src/redturtle/volto/tests/test_notfound.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.restapi.testing import RelativeSession
+from redturtle.volto.testing import REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
+from transaction import commit
+
+import unittest
+
+
+class TestNotFoundView(unittest.TestCase):
+    layer = REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.api_session = RelativeSession(self.portal_url, test=self)
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+    def test_html_request_to_unknown_url_returns_blank_404_page(self):
+        response = self.api_session.get(
+            "/this-page-does-not-exist", headers={"Accept": "text/html"}
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers.get("Content-Type", ""))
+        self.assertIn("404", response.text)
+        self.assertIn("Page not found", response.text)
+
+    def test_non_html_request_to_unknown_url_returns_json_error(self):
+        response = self.api_session.get(
+            "/this-page-does-not-exist", headers={"Accept": "application/json"}
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers.get("Content-Type"), "application/json")
+        self.assertEqual(response.json(), {"error_type": "NotFound"})
+
+    def test_request_without_accept_header_returns_json_error(self):
+        response = self.api_session.get(
+            "/this-page-does-not-exist", headers={"Accept": ""}
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers.get("Content-Type"), "application/json")
+        self.assertEqual(response.json(), {"error_type": "NotFound"})
+
+    def test_moved_content_is_redirected_instead_of_returning_404(self):
+        page = api.content.create(
+            container=self.portal, type="Document", title="Old page"
+        )
+        old_id = page.getId()
+        commit()
+
+        new_id = "new-page-id"
+        self.portal.manage_renameObject(id=old_id, new_id=new_id)
+        commit()
+
+        response = self.api_session.get(
+            f"/{old_id}",
+            headers={"Accept": "text/html"},
+            allow_redirects=False,
+        )
+
+        self.assertIn(response.status_code, (301, 302, 307))
+        self.assertIn(new_id, response.headers.get("Location", ""))

--- a/src/redturtle/volto/tests/test_notfound.py
+++ b/src/redturtle/volto/tests/test_notfound.py
@@ -33,6 +33,17 @@ class TestNotFoundView(unittest.TestCase):
         self.assertIn("404", response.text)
         self.assertIn("Page not found", response.text)
 
+    def test_html_request_with_italian_accept_language_is_translated(self):
+        response = self.api_session.get(
+            "/this-page-does-not-exist",
+            headers={"Accept": "text/html", "Accept-Language": "it"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('lang="it"', response.text)
+        self.assertIn("Pagina non trovata", response.text)
+        self.assertIn("La pagina che stai cercando non esiste.", response.text)
+
     def test_non_html_request_to_unknown_url_returns_json_error(self):
         response = self.api_session.get(
             "/this-page-does-not-exist", headers={"Accept": "application/json"}

--- a/src/redturtle/volto/tests/test_notfound.py
+++ b/src/redturtle/volto/tests/test_notfound.py
@@ -4,9 +4,12 @@ from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
+from plone.i18n.interfaces import ILanguageSchema
+from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import RelativeSession
 from redturtle.volto.testing import REDTURTLE_VOLTO_API_FUNCTIONAL_TESTING
 from transaction import commit
+from zope.component import getUtility
 
 import unittest
 
@@ -34,6 +37,24 @@ class TestNotFoundView(unittest.TestCase):
         self.assertIn("Page not found", response.text)
 
     def test_html_request_with_italian_accept_language_is_translated(self):
+        # Plone doesn't negotiate a language from the Accept-Language header
+        # unless the site is explicitly configured to do so, and "it" has to
+        # be listed as an available language to be picked.
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ILanguageSchema, prefix="plone")
+        original_languages = settings.available_languages
+        original_use_request_negotiation = settings.use_request_negotiation
+        settings.available_languages = ["en", "it"]
+        settings.use_request_negotiation = True
+        commit()
+
+        def _restore_settings():
+            settings.available_languages = original_languages
+            settings.use_request_negotiation = original_use_request_negotiation
+            commit()
+
+        self.addCleanup(_restore_settings)
+
         response = self.api_session.get(
             "/this-page-does-not-exist",
             headers={"Accept": "text/html", "Accept-Language": "it"},

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -8,6 +8,9 @@ extends =
 update-versions-file = test_plone52.cfg
 
 [versions]
+# twine 7.0.0 requires packaging>=26.1, which conflicts with the packaging
+# pin from Plone's requirements.txt
+twine = 6.2.0
 # https://raw.githubusercontent.com/RedTurtle/dist.design.plone/main/versions.cfg
 plone.app.iterate = 4.0.2
 plone.app.versioningbehavior = 1.4.6

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -7,6 +7,9 @@ extends =
 
 [versions]
 docutils =
+# twine 7.0.0 requires packaging>=26.1, which conflicts with the packaging==24.2
+# pin from Plone 6.0's requirements.txt
+twine = 6.2.0
 
 # Added by buildout at 2023-03-10 11:55:21.122842
 Products.AdvancedQuery = 4.2.1


### PR DESCRIPTION
Now when the plone backend is hit with a request that returns NotFound, it shows a custom blank 404 page instead of the default one.